### PR TITLE
fix: build mode for cdn from production to development

### DIFF
--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nemtus/symbol-sdk-typescript",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nemtus/symbol-sdk-typescript",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nemtus/symbol-sdk-typescript",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "JavaScript/TypeScript SDK for Symbol",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -16,7 +16,7 @@
     "build": "npm run build:cjs && npm run build:esm && npm run build:cdn",
     "build:cjs": "npm run clean:cjs && npx tsc --build --clean && npx tsc --target es5 --module commonjs --outDir cjs",
     "build:esm": "npm run clean:esm && npx tsc --build --clean && npx tsc --target esnext --module esnext --outDir esm",
-    "build:cdn": "npm run clean:cdn && webpack --mode=production",
+    "build:cdn": "npm run clean:cdn && webpack",
     "clean:cjs": "rimraf cjs",
     "clean:esm": "rimraf esm",
     "clean:cdn": "rimraf index.min.js && rimraf index.min.js.LICENSE.txt"


### PR DESCRIPTION
## Link to ticket

- no ticket

## What you did

What did you do with this pull?

- remove mode=production option
- bump version from 3.0.5 to 3.0.6

## What you will not do

What you will not do with this pull request? (If any. If not, "none" is OK) (If necessary, state when you will do it or create the issue will be remained.)

- Essentialy build configuration should be fix to prevent issue on production mode, but, this pull request does not fix it because the priority is to release it once it works as intended for the CDN. #9 

## What developers will be able to do (from the developer's perspective)

What will developers be able to do? (If any. If not, "none" is OK.) (from the developer's perspective)

- Developers can use CDN of this package without error.

## What will not be possible (from the developer's perspective)

What will be impossible to do? (If available. If not, "None" is OK.)

- This pull request does not fix the issue on production mode and it's build settings.

## Operation check

What kind of operation checks were performed?　What are the results?

- Locally, confirm it( https://gist.github.com/YasunoriMATSUOKA/432acf3eeca83897f55a549d2d99e34a ) works as expected with no production mode build file.

## Others

Reference information for reviewers (describe any implementation concerns or cautions)

- #9 

## Your Symbol address

* Input your address to get reward.

NDQQ5USL7GWKQMEN4JPGCDQCQK62SXPFHUEXOSQ
