### PR TITLE
ci: SHA-pin GitHub Actions (fix mirror-sync startup_failure) + add pinact check

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -22,7 +22,7 @@ pkg_dir="${repo_root}/sdk/javascript"
 readme="${repo_root}/README.md"
 
 # nemtus-owned GitHub workflows that must survive the strip below.
-nemtus_workflows=('publish.yml' 'mirror-sync.yml')
+nemtus_workflows=('publish.yml' 'mirror-sync.yml' 'pinact.yml')
 
 echo "==> patching ${pkg_dir}/package.json"
 cd "${pkg_dir}"

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -22,13 +22,13 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: dev
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
 

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,29 @@
+name: pinact (verify SHA pinning)
+
+# The repo enforces Settings -> Actions -> General -> "Require actions to be
+# pinned to a full-length commit SHA" (sha_pinning_required). Any workflow with
+# a tag/branch `uses:` ref fails at startup. This job validates pinning in PRs
+# (and pushes to dev) so the breakage surfaces here instead of silently in the
+# next scheduled mirror-sync run. Validate-only: `fix: "false"` never modifies
+# files or pushes, so no GitHub App / write token is needed.
+
+on:
+  pull_request: {}
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       should_publish: ${{ steps.decide.outputs.should_publish }}
       version: ${{ steps.decide.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: dev
 
@@ -62,11 +62,11 @@ jobs:
       run:
         working-directory: ./sdk/javascript
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: dev
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: dev
+          # This workflow never pushes to git (publishing is via OIDC), so don't
+          # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
+          persist-credentials: false
 
       - name: Compare dev version with npm
         id: decide
@@ -65,6 +68,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: dev
+          # This workflow never pushes to git (publishing is via OIDC), so don't
+          # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:


### PR DESCRIPTION
## Problem

The scheduled `mirror-sync` workflow (daily upstream sync) has been failing with `startup_failure` — _"This run likely failed because of a workflow file issue"_ — with **no job logs**.

Root cause, verified via the API (not assumed):

```
$ gh api repos/nemtus/symbol/actions/permissions
{ ..., "sha_pinning_required": true }
```

The repo enforces **Settings → Actions → General → "Require actions to be pinned to a full-length commit SHA"**. Both nemtus workflows referenced actions by mutable tag (`@v4`), so GitHub aborts them at startup before any step runs.

The repo's allow-list already includes `suzuki-shunsuke/pinact-action@*`, confirming pinning was the intended policy — the workflows were simply never pinned.

## Changes

- **Pin every `uses:` to a full commit SHA** (pinact convention `@<sha> # vX.Y.Z`) in `mirror-sync.yml` and `publish.yml`:
  - `actions/checkout` → `34e114876b0b11c390a56381ad16ebd13914f8d5` # v4.3.1
  - `actions/setup-node` → `49933ea5288caeca8642d1e84afbd3f7d6820020` # v4.4.0
- **Add `pinact.yml`** — validate-only `suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a` (# v3.0.0) with `fix: "false"` (no commit/push, no App token). Runs on PRs and pushes to `dev` so future pinning drift fails CI here instead of silently in the next scheduled run.
- **`apply-nemtus-patch.sh`** — add `pinact.yml` to `nemtus_workflows` so the workflow survives the upstream-strip step on every mirror-sync.

## Verification

- `grep -rnE 'uses:.*@(v[0-9]|main|master|dev)\b' .github/workflows/` → no matches; all 5 refs are 40-char SHAs with version comments.
- `pinact run --check` locally → exit 0.
- YAML lint of all three workflows → ok.

After merge: `gh workflow run mirror-sync.yml --repo nemtus/symbol` should now reach the steps (no `startup_failure`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned commit SHAs instead of version tags for enhanced security and reproducibility.
  * Added workflow validation to enforce consistent action pinning practices across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->