### PR TITLE
ci: SHA-pin actions, publish @nemtus/symbol-openapi spec, fix package license texts

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -6,7 +6,9 @@
 # nemtus rename-republish layer:
 #   - sdk/javascript package name -> @nemtus/symbol-sdk (version is left as-is,
 #     so it always matches upstream)
-#   - publishConfig.access=public (scoped package)
+#   - openapi package name -> @nemtus/symbol-openapi (version left as-is too);
+#     ships only the bundled spec (openapi3.yml/json + postman.json)
+#   - publishConfig.access=public (scoped packages)
 #   - repository / bugs / homepage point at nemtus/symbol
 #   - a "mirror" notice is prepended to the root README.md
 #   - upstream-provided GitHub automation is stripped (we keep only the nemtus
@@ -19,10 +21,11 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 pkg_dir="${repo_root}/sdk/javascript"
+openapi_dir="${repo_root}/openapi"
 readme="${repo_root}/README.md"
 
 # nemtus-owned GitHub workflows that must survive the strip below.
-nemtus_workflows=('publish.yml' 'mirror-sync.yml' 'pinact.yml')
+nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml')
 
 echo "==> patching ${pkg_dir}/package.json"
 cd "${pkg_dir}"
@@ -36,6 +39,103 @@ npm pkg set repository.url='git+https://github.com/nemtus/symbol.git'
 npm pkg set bugs='https://github.com/nemtus/symbol/issues'
 npm pkg set homepage='https://github.com/nemtus/symbol/tree/dev/sdk/javascript#readme'
 # NOTE: "version" is intentionally NOT modified — it always tracks upstream.
+
+echo "==> patching ${openapi_dir}/package.json"
+cd "${openapi_dir}"
+npm pkg set name='@nemtus/symbol-openapi'
+npm pkg set publishConfig.access='public'
+# Upstream declares "Apache 2.0", which is not a valid SPDX identifier (npm warns).
+# The bundled spec ships the full Apache-2.0 LICENSE (npm auto-includes it).
+npm pkg set license='Apache-2.0'
+# Upstream `repository` is already an object {type:git, url, directory:openapi}, so
+# only the url needs changing. Set it in place (no delete -> no key reordering),
+# which keeps the patch idempotent for the mirror-ci no-drift check.
+npm pkg set repository.url='git+https://github.com/nemtus/symbol.git'
+npm pkg set bugs='https://github.com/nemtus/symbol/issues'
+npm pkg set homepage='https://github.com/nemtus/symbol/tree/dev/openapi#readme'
+# Ship ONLY the bundled spec. The publish workflow runs `npm run build` then
+# flattens _build/* to the package root, so these names resolve as e.g.
+# `@nemtus/symbol-openapi/openapi3.json`. Upstream's "main: index.js" points at
+# a non-existent file, so replace it with spec-oriented exports.
+npm pkg delete main >/dev/null 2>&1 || true
+npm pkg set files[0]='openapi3.yml'
+npm pkg set files[1]='openapi3.json'
+npm pkg set files[2]='postman.json'
+npm pkg set exports['.']='./openapi3.json'
+npm pkg set exports['./openapi3.json']='./openapi3.json'
+npm pkg set exports['./openapi3.yml']='./openapi3.yml'
+npm pkg set exports['./postman.json']='./postman.json'
+# NOTE: "version" is intentionally NOT modified — it always tracks upstream.
+
+# sdk/javascript declares "license": "MIT" but upstream ships NO license text and
+# asserts NO copyright holder anywhere (the package.json "author" is contact
+# metadata, not a copyright statement; upstream's only MIT file leaves the holder
+# blank). So we do NOT fabricate a `Copyright (c) <name>` line — that would have us
+# author a legal attribution upstream never made. Instead we pass through the MIT
+# permission text with a truthful provenance note and an explicit disclaimer that
+# the mirror holds no copyright. Only create it when absent — never clobber a
+# license upstream might add later. (npm auto-includes a root LICENSE regardless
+# of the package's "files".)
+sdk_license="${pkg_dir}/LICENSE"
+echo "==> ensuring MIT LICENSE in ${sdk_license}"
+if [ ! -e "${sdk_license}" ]; then
+	cat > "${sdk_license}" <<'EOF'
+MIT License
+
+This package is an unmodified redistribution of `symbol-sdk` from the upstream
+project symbol/symbol (https://github.com/symbol/symbol), published by its
+authors — identified in the upstream package metadata as
+"Symbol Contributors <contributors@symbol.dev>" — under the MIT License. The
+nemtus mirror asserts no copyright over this software and changes nothing but the
+npm package name. The authoritative copyright and license are upstream's.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+EOF
+	echo "    LICENSE created"
+else
+	echo "    LICENSE already present (left as-is)"
+fi
+
+# Apache-2.0 §4(b): a derivative redistribution must state that files changed.
+# The root README notice does not travel inside the @nemtus/symbol-openapi tarball
+# (npm ships openapi/README.md), so add an equivalent notice there.
+openapi_readme="${openapi_dir}/README.md"
+echo "==> ensuring mirror notice in ${openapi_readme}"
+if [ -f "${openapi_readme}" ] && ! grep -qF '<!-- nemtus-mirror-notice -->' "${openapi_readme}"; then
+	tmp="$(mktemp)"
+	cat > "${tmp}" <<'EOF'
+<!-- nemtus-mirror-notice -->
+> **Note (nemtus mirror):** This package (`@nemtus/symbol-openapi`) is a content
+> mirror of the OpenAPI specification from
+> [`symbol/symbol`](https://github.com/symbol/symbol) (`openapi/`). The only change
+> from upstream is the npm package name; the specification content is unmodified.
+> Licensed under Apache-2.0. For the canonical project, see
+> [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
+EOF
+	cat "${openapi_readme}" >> "${tmp}"
+	mv "${tmp}" "${openapi_readme}"
+	echo "    notice inserted"
+else
+	echo "    notice already present or no README"
+fi
 
 echo "==> ensuring mirror notice in ${readme}"
 notice_marker='<!-- nemtus-mirror-notice -->'

--- a/.github/workflows/mirror-ci.yml
+++ b/.github/workflows/mirror-ci.yml
@@ -46,7 +46,7 @@ jobs:
           fi
       - name: Assert no merge conflict markers
         run: |
-          if git grep -nE '^(<{7}|={7}|>{7})( |$)' -- . ':(exclude).github/workflows/mirror-ci.yml'; then
+          if git grep -nE '^(<{7}|={7}|>{7})( |$)' -- .; then
             echo "::error::Merge conflict markers found." >&2
             exit 1
           fi

--- a/.github/workflows/mirror-ci.yml
+++ b/.github/workflows/mirror-ci.yml
@@ -1,0 +1,158 @@
+name: mirror-ci (parity + publishability)
+
+# Mirror-specific CI for the @nemtus/symbol-sdk republish mirror. Source is identical
+# to upstream symbol/symbol, so this validates that each sync PR (mirror-sync.yml) and
+# each push to dev still: (1) has the rename layer cleanly applied, (2) lints, (3) tests,
+# (4) builds the exact artifacts publish.yml will publish, and (5) passes the crypto /
+# catbuffer vectors. Catches sync/merge/rename breakage BEFORE merge and publish.
+#
+# NOTE: this workflow is kept by apply-nemtus-patch.sh's nemtus_workflows allow-list, so
+# mirror-sync does not strip it. The :jenkins script variants (JUnit/lcov for upstream's
+# Jenkinsfile), bundle:clean (local cleanup) and generate-docs (typedoc, not in npm
+# "files") are intentionally not run here.
+
+on:
+  pull_request: {}
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Mirror-specific: re-running the idempotent rename patch must produce NO diff.
+  # This proves name=@nemtus/symbol-sdk, metadata, README notice, and the workflow
+  # strip are all intact, and (via the conflict-marker grep) that no merge markers leaked.
+  verify-rename-layer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - name: Re-apply rename layer and assert no drift
+        run: |
+          bash .github/scripts/apply-nemtus-patch.sh
+          if ! git diff --exit-code; then
+            echo "::error::Rename layer drift - apply-nemtus-patch.sh produced changes." >&2
+            exit 1
+          fi
+      - name: Assert no merge conflict markers
+        run: |
+          if git grep -nE '^(<{7}|={7}|>{7})( |$)' -- . ':(exclude).github/workflows/mirror-ci.yml'; then
+            echo "::error::Merge conflict markers found." >&2
+            exit 1
+          fi
+
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./sdk/javascript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./sdk/javascript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm test
+
+  # Same build publish.yml performs, so a broken publishable build fails here at PR time.
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./sdk/javascript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run bundle                              # dist/* (webpack + wasm-pack)
+      - run: npx tsc -p ./tsconfig/build-bindings.json   # ts/src/* declarations
+
+  vectors:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        blockchain: [nem, symbol]
+    defaults:
+      run:
+        working-directory: ./sdk/javascript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run vectors
+        env:
+          BLOCKCHAIN: ${{ matrix.blockchain }}
+
+  catvectors:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./sdk/javascript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run catvectors
+        env:
+          SCHEMAS_PATH: ${{ github.workspace }}/tests/vectors
+
+  # OpenAPI parity/build gate: the spec must still lint and bundle cleanly, so a
+  # broken sync never reaches openapi-publish.yml. We lint the source spec, bundle
+  # it (the exact artifacts the publish flow ships), and lint the bundle. We do NOT
+  # run `verify-links` here — it fetches external URLs and would make the gate flaky.
+  openapi:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./openapi
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run lint                  # redocly lint of the source spec
+      - run: npm run build                 # bundle -> _build/openapi3.yml/json + postman.json
+      - run: npm run lint:openapi:build    # redocly lint of the bundled output

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -47,6 +47,12 @@ jobs:
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
 
+      # Pin the runtime so the gate doesn't depend on the runner's preinstalled
+      # Node/npm.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
       - name: Compare dev version with npm
         id: decide
         run: |
@@ -94,7 +100,7 @@ jobs:
 
       # OIDC trusted publishing requires npm CLI >= 11.5.1.
       - name: Upgrade npm to OIDC-capable version
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       # Idempotent safety net: ensures the @nemtus/symbol-openapi name, files and
       # exports are set even on a manual dispatch from a not-yet-patched tree.

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -24,6 +24,12 @@ on:
       - 'openapi/package.json'
   workflow_dispatch:
 
+# Minimal default for every job; the publish job re-grants id-token: write below
+# for npm Trusted Publishing (OIDC). Keeps the check job from inheriting a broad
+# GITHUB_TOKEN (CodeQL: actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 jobs:
   # Decide whether the version on dev differs from what is already on npm.
   # Kept separate so the npm-production approval prompt only appears when we

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -1,0 +1,104 @@
+name: publish @nemtus/symbol-openapi
+
+# Single, trusted publish path for the scoped mirror spec package.
+# Ships ONLY the bundled OpenAPI spec (openapi3.yml/json + postman.json) so
+# downstream REST-client codegen can pin one self-owned source.
+# Publishing uses npm Trusted Publishing (OIDC) — NO long-lived NPM_TOKEN.
+# The `npm-production` environment carries a required-reviewers protection rule,
+# so every publish pauses for manual approval.
+#
+# Triggers:
+#   - push to dev touching openapi/package.json (i.e. a merged mirror-sync PR
+#     that bumped the upstream OpenAPI version) -> auto-publish, gated by approval
+#   - manual workflow_dispatch
+#
+# npmjs.com Trusted Publisher config must match:
+#   repository:  nemtus/symbol
+#   workflow:    openapi-publish.yml
+#   environment: npm-production
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'openapi/package.json'
+  workflow_dispatch:
+
+jobs:
+  # Decide whether the version on dev differs from what is already on npm.
+  # Kept separate so the npm-production approval prompt only appears when we
+  # actually intend to publish.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          # This workflow never pushes to git (publishing is via OIDC), so don't
+          # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
+          persist-credentials: false
+
+      - name: Compare dev version with npm
+        id: decide
+        run: |
+          version="$(node -p "require('./openapi/package.json').version")"
+          npm_version="$(npm view @nemtus/symbol-openapi version 2>/dev/null || echo '0.0.0')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if [ "${version}" != "${npm_version}" ]; then
+            echo "npm ${npm_version} -> ${version}: will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm already at ${npm_version}: nothing to publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-production
+    permissions:
+      id-token: write   # required for npm Trusted Publishing (OIDC)
+      contents: read
+    defaults:
+      run:
+        working-directory: ./openapi
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          # This workflow never pushes to git (publishing is via OIDC), so don't
+          # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing requires npm CLI >= 11.5.1.
+      - name: Upgrade npm to OIDC-capable version
+        run: npm install -g npm@latest
+
+      # Idempotent safety net: ensures the @nemtus/symbol-openapi name, files and
+      # exports are set even on a manual dispatch from a not-yet-patched tree.
+      - name: Apply nemtus rename layer (@nemtus/symbol-openapi)
+        run: bash ../.github/scripts/apply-nemtus-patch.sh
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Bundle the modular spec into single files (openapi3.yml/json + postman.json).
+      - name: Build bundled spec
+        run: npm run build
+
+      # Flatten built artifacts to the package root so they ship at the names the
+      # package.json "files"/"exports" reference (e.g. @nemtus/symbol-openapi/openapi3.json).
+      - name: Stage spec artifacts at package root
+        run: cp _build/openapi3.yml _build/openapi3.json _build/postman.json .
+
+      - name: Publish to npm (OIDC, provenance)
+        run: npm publish --access public

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -51,7 +51,14 @@ jobs:
         id: decide
         run: |
           version="$(node -p "require('./openapi/package.json').version")"
-          npm_version="$(npm view @nemtus/symbol-openapi version 2>/dev/null || echo '0.0.0')"
+          # Fail closed: the package already exists, so if `npm view` returns no
+          # version it's a transient registry/network error. Falling back to 0.0.0
+          # would falsely flag a publish (and an unnecessary npm-production approval,
+          # then a failing publish), so abort instead of guessing.
+          if ! npm_version="$(npm view @nemtus/symbol-openapi version 2>/dev/null)" || [ -z "${npm_version}" ]; then
+            echo "::error::could not read @nemtus/symbol-openapi version from npm; aborting to avoid a false publish." >&2
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           if [ "${version}" != "${npm_version}" ]; then
             echo "npm ${npm_version} -> ${version}: will publish."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,12 @@ on:
       - 'sdk/javascript/package.json'
   workflow_dispatch:
 
+# Minimal default for every job; the publish job re-grants id-token: write below
+# for npm Trusted Publishing (OIDC). Keeps the check job from inheriting a broad
+# GITHUB_TOKEN (CodeQL: actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 jobs:
   # Decide whether the version on dev differs from what is already on npm.
   # Kept separate so the npm-production approval prompt only appears when we
@@ -43,7 +49,14 @@ jobs:
         id: decide
         run: |
           version="$(node -p "require('./sdk/javascript/package.json').version")"
-          npm_version="$(npm view @nemtus/symbol-sdk version 2>/dev/null || echo '0.0.0')"
+          # Fail closed: the package already exists, so if `npm view` returns no
+          # version it's a transient registry/network error. Falling back to 0.0.0
+          # would falsely flag a publish (and an unnecessary npm-production approval,
+          # then a failing publish), so abort instead of guessing.
+          if ! npm_version="$(npm view @nemtus/symbol-sdk version 2>/dev/null)" || [ -z "${npm_version}" ]; then
+            echo "::error::could not read @nemtus/symbol-sdk version from npm; aborting to avoid a false publish." >&2
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           if [ "${version}" != "${npm_version}" ]; then
             echo "npm ${npm_version} -> ${version}: will publish."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,12 @@ jobs:
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
 
+      # Pin the runtime so the gate doesn't depend on the runner's preinstalled
+      # Node/npm.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
       - name: Compare dev version with npm
         id: decide
         run: |
@@ -92,7 +98,7 @@ jobs:
 
       # OIDC trusted publishing requires npm CLI >= 11.5.1.
       - name: Upgrade npm to OIDC-capable version
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       # Idempotent safety net: ensures the @nemtus/symbol-sdk name is set even on
       # a manual dispatch from a not-yet-patched tree.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,3 +1,12 @@
+<!-- nemtus-mirror-notice -->
+> **Note (nemtus mirror):** This package (`@nemtus/symbol-openapi`) is a content
+> mirror of the OpenAPI specification from
+> [`symbol/symbol`](https://github.com/symbol/symbol) (`openapi/`). The only change
+> from upstream is the npm package name; the specification content is unmodified.
+> Licensed under Apache-2.0. For the canonical project, see
+> [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
 # symbol-openapi
 
 OpenAPI specification for catapult-rest.

--- a/openapi/package.json
+++ b/openapi/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "symbol-openapi",
+  "name": "@nemtus/symbol-openapi",
   "version": "1.0.5",
   "description": "OpenAPI Specification of catapult-rest",
-  "main": "index.js",
   "scripts": {
     "lint:openapi:source": "redocly lint --config .redocly.yaml spec/openapi.yml",
     "lint:openapi:build": "redocly lint --config .redocly.yaml _build/openapi3.yml _build/openapi3.json",
@@ -19,18 +18,29 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/symbol/symbol.git",
+    "url": "git+https://github.com/nemtus/symbol.git",
     "directory": "openapi"
   },
-  "license": "Apache 2.0",
-  "bugs": {
-    "url": "https://github.com/symbol/symbol/issues"
-  },
-  "homepage": "https://github.com/symbol/symbol/tree/dev/openapi#readme",
-  "dependencies": {},
+  "license": "Apache-2.0",
+  "bugs": "https://github.com/nemtus/symbol/issues",
+  "homepage": "https://github.com/nemtus/symbol/tree/dev/openapi#readme",
   "devDependencies": {
     "@redocly/cli": "^2.31.5",
     "markdown-link-check": "^3.14.2",
     "openapi-to-postmanv2": "^6.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "openapi3.yml",
+    "openapi3.json",
+    "postman.json"
+  ],
+  "exports": {
+    ".": "./openapi3.json",
+    "./openapi3.json": "./openapi3.json",
+    "./openapi3.yml": "./openapi3.yml",
+    "./postman.json": "./postman.json"
   }
 }

--- a/sdk/javascript/LICENSE
+++ b/sdk/javascript/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+This package is an unmodified redistribution of `symbol-sdk` from the upstream
+project symbol/symbol (https://github.com/symbol/symbol), published by its
+authors — identified in the upstream package metadata as
+"Symbol Contributors <contributors@symbol.dev>" — under the MIT License. The
+nemtus mirror asserts no copyright over this software and changes nothing but the
+npm package name. The authoritative copyright and license are upstream's.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

This branch bundles the in-flight mirror CI/security work with the new OpenAPI
spec publishing pipeline and license corrections.

### SHA-pin / security (already on this branch)
- Pin GitHub Actions to commit SHAs to fix the mirror-sync `startup_failure`.
- Stop persisting `GITHUB_TOKEN` in `publish.yml` checkouts.

### OpenAPI spec publishing (new)
- Republish the bundled OpenAPI spec as **`@nemtus/symbol-openapi`** (spec
  artifacts only: `openapi3.yml`/`openapi3.json` + `postman.json`), so downstream
  REST-client codegen can pin one self-owned source instead of chasing the
  upstream spec across repos. The version tracks upstream (1.0.5).
- `openapi-publish.yml`: version-gated publish via npm Trusted Publishing
  (OIDC, no `NPM_TOKEN`), gated by the `npm-production` environment approval.
- `mirror-ci.yml`: OpenAPI lint/build parity gate (added next to the SDK parity
  jobs; `verify-links` skipped as it is network-flaky).
- `apply-nemtus-patch.sh`: idempotent openapi rename layer (name, public access,
  files/exports shipping only the bundled spec) + allow-list entry so
  mirror-sync keeps the workflow.

### License corrections (new)
- **openapi**: fix the SPDX id `Apache 2.0` -> `Apache-2.0`; add an Apache-2.0
  §4(b) change notice to `openapi/README.md`.
- **sdk**: add a pass-through MIT `LICENSE` (MIT permission text + a truthful
  provenance note; **no fabricated copyright-holder line**) so the republished
  tarball carries license text. `catapult`/`rest` stay unpublished (LGPL/commercial).

## Notes
- Manual npm setup is already done: bootstrap publish of
  `@nemtus/symbol-openapi@1.0.5` and the Trusted Publisher config
  (repo `nemtus/symbol`, workflow `openapi-publish.yml`, env `npm-production`).
  Because the published version already matches, merging this will **not**
  re-publish; the next upstream version bump will auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `@nemtus/symbol-openapi` npm package publishing, exposing bundled OpenAPI 3 and Postman specifications.

* **Chores**
  * Enhanced CI/CD pipelines with dedicated mirror verification job and improved security defaults.
  * Updated package metadata and added MIT license files across mirror components.

* **Documentation**
  * Added mirror source attribution notice to OpenAPI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->