### PR TITLE
ci(mirror): content-based sync guard + require merge-commit

### DIFF
--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -6,6 +6,15 @@ name: mirror-sync (upstream symbol/symbol)
 # reviews and merges it; publishing then happens via publish.yml when the merged
 # package.json version differs from npm.
 #
+# IMPORTANT: merge these sync PRs with a MERGE COMMIT (never "Squash and merge").
+# The sync branch carries upstream/dev as a parent; squashing would drop that
+# parent, leaving upstream/dev out of dev's ancestry again and making every run
+# replay the entire upstream history as a giant diff.
+#
+# The "build and decide" step below is CONTENT-based: it builds the merged +
+# re-renamed tree and only opens a PR when that tree actually differs from dev.
+# This is robust even if dev's ancestry is ever disconnected from upstream/dev.
+#
 # Requires repo setting: Settings -> Actions -> General ->
 #   "Allow GitHub Actions to create and approve pull requests" = enabled.
 
@@ -39,28 +48,39 @@ jobs:
           git remote add upstream https://github.com/symbol/symbol.git
           git fetch upstream dev
 
-      - name: Stop if already up to date
+      - name: Build sync branch and decide (content-based)
         id: check
         run: |
+          # Fast path: if dev already contains every upstream commit, stop early.
           if git merge-base --is-ancestor upstream/dev HEAD; then
             echo "dev already contains upstream/dev; nothing to sync."
             echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "upstream_sha=$(git rev-parse --short upstream/dev)" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Build sync branch (merge upstream + re-apply rename layer)
-        if: steps.check.outputs.changed == 'true'
-        run: |
-          branch="sync/upstream-${{ steps.check.outputs.upstream_sha }}"
-          echo "SYNC_BRANCH=${branch}" >> "$GITHUB_ENV"
+          upstream_sha="$(git rev-parse --short upstream/dev)"
+          branch="sync/upstream-${upstream_sha}"
           git checkout -B "${branch}"
           # Prefer upstream on any conflict; the rename layer is restored next.
           git merge -X theirs --no-edit --no-commit upstream/dev || true
           bash .github/scripts/apply-nemtus-patch.sh
           git add -A
-          git commit --no-edit -m "chore: sync upstream ${{ steps.check.outputs.upstream_sha }} + nemtus republish layer"
+
+          # Content guard: if the merged + re-renamed tree is identical to dev,
+          # there is nothing to sync even though ancestry differs. Don't open a
+          # noise PR — abort the in-progress merge and return to dev.
+          if git diff --cached --quiet; then
+            echo "merged tree == dev; nothing to sync."
+            git merge --abort 2>/dev/null || git reset --hard HEAD
+            git checkout dev
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit --no-edit -m "chore: sync upstream ${upstream_sha} + nemtus republish layer"
+          echo "SYNC_BRANCH=${branch}" >> "$GITHUB_ENV"
+          echo "upstream_sha=${upstream_sha}" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Push sync branch and open PR
         if: steps.check.outputs.changed == 'true'


### PR DESCRIPTION
## Why
The daily `mirror-sync` cron produced PR #22 with a huge-looking diff (1343 upstream commits replayed). Root cause: the 2026-06 migration commit `83da7a6f6` snapshotted upstream's tree onto the old 2022 fork tip instead of merging `upstream/dev`, so `upstream/dev` is **not in `dev`'s ancestry**. The old guard `git merge-base --is-ancestor upstream/dev HEAD` is therefore always false → a PR is opened every run and the full upstream history shows as "new".

## What
- **Content-based guard**: build the merged + re-renamed tree first, then open a PR only when that tree actually differs from `dev` (`git diff --cached --quiet`). Robust even while ancestry is disconnected — no more empty/noise PRs.
- **Keep** the `--is-ancestor` fast path (correctly short-circuits once ancestry is healthy).
- **Document** that these sync PRs must be merged with a **merge commit, never squash**, so `upstream/dev` stays in `dev`'s ancestry.

## Companion action
PR #22 itself should be merged with a **merge commit** (not squash) — that single action reconnects `upstream/dev` into `dev`'s ancestry and makes all future sync diffs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized repository synchronization workflow to prevent unnecessary pull requests by implementing content-aware checks.
  * Improved merge history handling and documentation to ensure proper preservation of upstream branches during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->