### PR TITLE
ci: harden supply chain with Socket (App + Firewall) at zero cost

### DIFF
--- a/.github/SUPPLY-CHAIN-SECURITY.md
+++ b/.github/SUPPLY-CHAIN-SECURITY.md
@@ -1,0 +1,65 @@
+<!-- nemtus-owned doc. Not from upstream symbol/symbol; survives mirror-sync. -->
+# Supply-chain hardening (Socket) — nemtus/symbol
+
+This mirror ingests upstream `symbol/symbol` dependencies automatically every day
+(`mirror-sync.yml`) and republishes npm packages via OIDC. To stop a malicious or
+compromised dependency from reaching a release, we layer [Socket](https://socket.dev)
+on top. **Cost: $0** — Socket is free and unlimited for public/open-source repos, and
+Socket Firewall Free needs no account or API key.
+
+## The three layers
+
+1. **Socket GitHub App — PR-time scanning (all ecosystems).**
+   Scans dependency-manifest changes on every PR (especially the daily `mirror-sync`
+   PR) and posts a comment + a Check Run. Covers npm, Python, Rust, and C/C++
+   (`client/catapult/conanfile.py`, `vcpkg.json`). Tuned by [`socket.yml`](../socket.yml).
+
+2. **Socket Firewall (`sfw`) — install-time hard gate in CI.**
+   Every `npm ci` in `mirror-ci.yml`, `publish.yml`, and `openapi-publish.yml` runs as
+   `sfw npm ci`. `sfw` is installed by Socket's official action, **pinned to a commit SHA**
+   (`SocketDev/action@…  # v1.3.2`, `mode: firewall-free`) — so `pinact.yml` enforces the
+   pin and Dependabot bumps it for us; no hand-edited version string to maintain. A
+   confirmed-malicious package fails the install — and the job — before it can build or
+   publish. `sfw` supports npm/yarn/pnpm, pip/uv, and cargo; it does **not** support
+   C/C++ (Conan/vcpkg), so C++ relies on layers 1 & 3.
+
+3. **Required status check — merge-time hard gate (all ecosystems).**
+   The Socket check is a required status check on `dev`, so no PR (including C++ changes)
+   merges while Socket flags an unresolved high-severity risk.
+
+## One-time manual setup (no code, $0)
+
+- **Install the Socket GitHub App** on `nemtus/symbol` from the GitHub Marketplace
+  (public repo → free). It picks up `socket.yml` automatically.
+- **Make the Socket check required:** Settings → Branches → branch protection for `dev`
+  → Require status checks to pass → add the Socket check. Do this only after confirming
+  the dashboard alert policy doesn't block on benign alerts (e.g. native code in crypto
+  deps), or every PR will need a manual override.
+- Optionally review the org/repo alert policy in the Socket dashboard (block vs. warn).
+
+- Confirm **Dependabot is enabled** (default-on for public repos). The nemtus
+  `.github/dependabot.yml` is scoped to the `github-actions` ecosystem only, so it keeps
+  the SHA-pinned actions — including the Socket gate — current via reviewed weekly PRs,
+  without touching the mirror's upstream-tracked npm/cargo deps.
+
+Both `socket.yml` (repo root) and `.github/dependabot.yml` are **owned by the nemtus
+layer**: `.github/scripts/apply-nemtus-patch.sh` rewrites them verbatim on every sync, so
+edit them in that script (not the files) — `mirror-ci.yml`'s no-drift check enforces this.
+
+## Local developer use (optional, free)
+
+Block malware on your own machine / in Jenkins by prefixing `sfw`:
+
+```sh
+npm i -g sfw        # latest is fine locally; CI pins via SocketDev/action
+sfw npm ci          # JavaScript (sdk/javascript, openapi, client/rest)
+sfw pip install -r requirements.txt   # Python (sdk/python, catbuffer/parser)
+sfw cargo fetch     # Rust/WASM (sdk/javascript/wasm)
+```
+
+## Known limits
+
+- C/C++ (Conan/vcpkg) has **no free install-time block** — covered by layers 1 & 3 only.
+- `sfw` Free blocks only human-verified confirmed malware; AI-flagged (unconfirmed)
+  packages are warned, not blocked — the App covers those at PR time.
+- Socket does not auto-update dependencies (that's Dependabot/Renovate's job, out of scope).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot — nemtus mirror layer. Owned by .github/scripts/apply-nemtus-patch.sh,
+# which rewrites this file verbatim on every upstream sync (mirror-ci.yml enforces no
+# drift). Edit it THERE, not here.
+#
+# Scoped to github-actions ONLY: it keeps our SHA-pinned actions current — including
+# SocketDev/action, the supply-chain gate — behind a human-reviewed PR, while pinact.yml
+# re-asserts SHA pinning. We deliberately do NOT enable npm/cargo/pip updates: this is a
+# mirror whose package deps track upstream symbol/symbol, so dependency PRs against them
+# would diverge the mirror from upstream.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    labels: [dependencies]
+    commit-message:
+      prefix: '[dependency]'
+    # Buffer so a freshly published action release has time to surface regressions
+    # before Dependabot proposes it (Socket's recommended cooldown).
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -190,7 +190,7 @@ triggerPaths:
   - '**/package.json'
   - '**/package-lock.json'
   - '**/pyproject.toml'
-  - '**/requirements.txt'
+  - '**/*requirements*.txt'   # requirements.txt, dev_requirements.txt, lint_requirements.txt
   - '**/poetry.lock'
   - '**/Cargo.toml'
   - '**/Cargo.lock'

--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -11,9 +11,13 @@
 #   - publishConfig.access=public (scoped packages)
 #   - repository / bugs / homepage point at nemtus/symbol
 #   - a "mirror" notice is prepended to the root README.md
+#   - socket.yml (Socket supply-chain config) is (re)written at the repo root so it
+#     survives every upstream sync (Socket is free/unlimited for public repos)
 #   - upstream-provided GitHub automation is stripped (we keep only the nemtus
-#     workflows), so upstream CI (e.g. codeql-analysis) and Dependabot do not run
-#     against the mirror.
+#     workflows), so upstream CI (e.g. codeql-analysis) does not run against the mirror
+#   - Dependabot is replaced with a nemtus github-actions-only config (.github/
+#     dependabot.yml) that keeps the SHA-pinned actions — including the Socket gate —
+#     current, without opening npm/cargo PRs that would diverge from upstream
 #
 # Running it repeatedly produces the same result. The mirror-sync workflow runs
 # it after every upstream merge.
@@ -160,6 +164,58 @@ else
 	echo "    notice already present"
 fi
 
+# Socket (https://socket.dev) supply-chain config. Owned by the nemtus layer and
+# rewritten verbatim each run so it always survives an upstream sync and the
+# mirror-ci no-drift check stays green. Keep this heredoc byte-identical to the
+# committed socket.yml.
+socket_yml="${repo_root}/socket.yml"
+echo "==> writing ${socket_yml}"
+cat > "${socket_yml}" <<'EOF'
+# socket.yml — Socket (https://socket.dev) configuration for the nemtus/symbol mirror.
+#
+# Managed by the nemtus republish layer: .github/scripts/apply-nemtus-patch.sh
+# rewrites this file verbatim on every upstream sync, so edit it THERE, not here —
+# otherwise the next mirror-sync reverts your change, and mirror-ci.yml's no-drift
+# check fails when this file and the script disagree.
+#
+# Socket is free and unlimited for public/open-source repos, so this adds supply
+# chain scanning at zero cost. Scope: every dependency manifest in the monorepo —
+# npm (sdk/javascript, openapi, client/rest), Python (sdk/python, catbuffer/parser),
+# Rust/WASM (sdk/javascript/wasm) and C/C++ (client/catapult: conanfile.py, vcpkg.json).
+version: 2
+
+# Run a PR scan only when a dependency manifest actually changes (gitignore-style
+# globs matched against the PR's changed files). The daily mirror-sync PR bumps these.
+triggerPaths:
+  - '**/package.json'
+  - '**/package-lock.json'
+  - '**/pyproject.toml'
+  - '**/requirements.txt'
+  - '**/poetry.lock'
+  - '**/Cargo.toml'
+  - '**/Cargo.lock'
+  - '**/conanfile.py'
+  - '**/vcpkg.json'
+
+# High-signal supply-chain alerts for a mirror that ingests upstream deps daily.
+# issueRules is coarse (on/off per alert type); fine-grained block-vs-warn tuning
+# lives in the Socket dashboard, and the required-status-check branch-protection rule
+# is what turns a failing scan into a hard merge block. Only documented slugs are
+# used here to avoid silently breaking the config.
+issueRules:
+  malware: true
+  installScripts: true
+  didYouMean: true     # typosquats
+  gitDependency: true
+  telemetry: false     # noisy for a crypto/blockchain dep tree; left to the dashboard
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  # Do NOT list the mirror-sync bot here: its automated PRs are exactly what we scan.
+  ignoreUsers: []
+EOF
+
 echo "==> stripping upstream GitHub automation (keeping only nemtus workflows)"
 workflows_dir="${repo_root}/.github/workflows"
 if [ -d "${workflows_dir}" ]; then
@@ -172,7 +228,47 @@ if [ -d "${workflows_dir}" ]; then
 	find "${workflows_dir}" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) \
 		"${keep_args[@]}" -print -delete
 fi
-# Upstream Dependabot config would open dependency PRs against the mirror; remove it.
-rm -f "${repo_root}/.github/dependabot.yaml" "${repo_root}/.github/dependabot.yml"
+# Dependabot: replace upstream's multi-ecosystem config (npm/cargo/github-actions —
+# the npm/cargo updates would open PRs that diverge the mirror from upstream) with a
+# nemtus-owned github-actions-ONLY config. This keeps the SHA-pinned actions current,
+# including SocketDev/action (our supply-chain gate), behind a reviewed PR. Owned by
+# this script and rewritten verbatim, so it survives every sync (matches the committed
+# file -> mirror-ci no-drift check stays green). Remove upstream's .yaml so only ours
+# (.yml) remains (GitHub errors if both exist).
+rm -f "${repo_root}/.github/dependabot.yaml"
+dependabot_yml="${repo_root}/.github/dependabot.yml"
+echo "==> writing ${dependabot_yml}"
+cat > "${dependabot_yml}" <<'EOF'
+# Dependabot — nemtus mirror layer. Owned by .github/scripts/apply-nemtus-patch.sh,
+# which rewrites this file verbatim on every upstream sync (mirror-ci.yml enforces no
+# drift). Edit it THERE, not here.
+#
+# Scoped to github-actions ONLY: it keeps our SHA-pinned actions current — including
+# SocketDev/action, the supply-chain gate — behind a human-reviewed PR, while pinact.yml
+# re-asserts SHA pinning. We deliberately do NOT enable npm/cargo/pip updates: this is a
+# mirror whose package deps track upstream symbol/symbol, so dependency PRs against them
+# would diverge the mirror from upstream.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: sunday
+    labels: [dependencies]
+    commit-message:
+      prefix: '[dependency]'
+    # Buffer so a freshly published action release has time to surface regressions
+    # before Dependabot proposes it (Socket's recommended cooldown).
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+EOF
 
 echo "==> done"

--- a/.github/workflows/mirror-ci.yml
+++ b/.github/workflows/mirror-ci.yml
@@ -6,6 +6,12 @@ name: mirror-ci (parity + publishability)
 # (4) builds the exact artifacts publish.yml will publish, and (5) passes the crypto /
 # catbuffer vectors. Catches sync/merge/rename breakage BEFORE merge and publish.
 #
+# Supply-chain hardening: every `npm ci` runs under Socket Firewall (`sfw`, free, no
+# account), installed via Socket's SHA-pinned action (kept current by Dependabot), so a
+# confirmed-malicious dependency pulled in by an upstream sync fails the install — and
+# thus the job — before it can build or be published. Pairs with the Socket GitHub App
+# (PR-time scanning) and the required-status-check on dev.
+#
 # NOTE: this workflow is kept by apply-nemtus-patch.sh's nemtus_workflows allow-list, so
 # mirror-sync does not strip it. The :jenkins script variants (JUnit/lcov for upstream's
 # Jenkinsfile), bundle:clean (local cleanup) and generate-docs (typedoc, not in npm
@@ -63,7 +69,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-      - run: npm ci
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable). `sfw` then wraps the install so
+      # confirmed-malicious packages fail before they're fetched — a hard supply-chain gate.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw npm ci
       - run: npm run lint
 
   test:
@@ -78,7 +90,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-      - run: npm ci
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable). `sfw` then wraps the install so
+      # confirmed-malicious packages fail before they're fetched — a hard supply-chain gate.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw npm ci
       - run: npm test
 
   # Same build publish.yml performs, so a broken publishable build fails here at PR time.
@@ -94,7 +112,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-      - run: npm ci
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable). `sfw` then wraps the install so
+      # confirmed-malicious packages fail before they're fetched — a hard supply-chain gate.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw npm ci
       - run: npm run bundle                              # dist/* (webpack + wasm-pack)
       - run: npx tsc -p ./tsconfig/build-bindings.json   # ts/src/* declarations
 
@@ -114,7 +138,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-      - run: npm ci
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable). `sfw` then wraps the install so
+      # confirmed-malicious packages fail before they're fetched — a hard supply-chain gate.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw npm ci
       - run: npm run vectors
         env:
           BLOCKCHAIN: ${{ matrix.blockchain }}
@@ -131,7 +161,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-      - run: npm ci
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable). `sfw` then wraps the install so
+      # confirmed-malicious packages fail before they're fetched — a hard supply-chain gate.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw npm ci
       - run: npm run catvectors
         env:
           SCHEMAS_PATH: ${{ github.workspace }}/tests/vectors
@@ -152,7 +188,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-      - run: npm ci
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable). `sfw` then wraps the install so
+      # confirmed-malicious packages fail before they're fetched — a hard supply-chain gate.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw npm ci
       - run: npm run lint                  # redocly lint of the source spec
       - run: npm run build                 # bundle -> _build/openapi3.yml/json + postman.json
       - run: npm run lint:openapi:build    # redocly lint of the bundled output

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -107,8 +107,15 @@ jobs:
       - name: Apply nemtus rename layer (@nemtus/symbol-openapi)
         run: bash ../.github/scripts/apply-nemtus-patch.sh
 
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable) — a hard supply-chain gate on the
+      # publish path. `sfw` wraps the install so malware fails before it's fetched.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
-        run: npm ci
+        run: sfw npm ci
 
       # Bundle the modular spec into single files (openapi3.yml/json + postman.json).
       - name: Build bundled spec

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,8 +105,15 @@ jobs:
       - name: Apply nemtus rename layer (@nemtus/symbol-sdk)
         run: bash ../../.github/scripts/apply-nemtus-patch.sh
 
+      # Socket Firewall: Free (no account/API key) via Socket's official SHA-pinned
+      # action (pinact-enforced, Dependabot-updatable) — a hard supply-chain gate on the
+      # publish path. `sfw` wraps the install so malware fails before it's fetched.
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - name: Install dependencies
-        run: npm ci
+        run: sfw npm ci
 
       # Build artifacts referenced by package.json "files": dist/* and ts/src/*.
       - name: Build browser bundle (dist/*)

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,43 @@
+# socket.yml — Socket (https://socket.dev) configuration for the nemtus/symbol mirror.
+#
+# Managed by the nemtus republish layer: .github/scripts/apply-nemtus-patch.sh
+# rewrites this file verbatim on every upstream sync, so edit it THERE, not here —
+# otherwise the next mirror-sync reverts your change, and mirror-ci.yml's no-drift
+# check fails when this file and the script disagree.
+#
+# Socket is free and unlimited for public/open-source repos, so this adds supply
+# chain scanning at zero cost. Scope: every dependency manifest in the monorepo —
+# npm (sdk/javascript, openapi, client/rest), Python (sdk/python, catbuffer/parser),
+# Rust/WASM (sdk/javascript/wasm) and C/C++ (client/catapult: conanfile.py, vcpkg.json).
+version: 2
+
+# Run a PR scan only when a dependency manifest actually changes (gitignore-style
+# globs matched against the PR's changed files). The daily mirror-sync PR bumps these.
+triggerPaths:
+  - '**/package.json'
+  - '**/package-lock.json'
+  - '**/pyproject.toml'
+  - '**/requirements.txt'
+  - '**/poetry.lock'
+  - '**/Cargo.toml'
+  - '**/Cargo.lock'
+  - '**/conanfile.py'
+  - '**/vcpkg.json'
+
+# High-signal supply-chain alerts for a mirror that ingests upstream deps daily.
+# issueRules is coarse (on/off per alert type); fine-grained block-vs-warn tuning
+# lives in the Socket dashboard, and the required-status-check branch-protection rule
+# is what turns a failing scan into a hard merge block. Only documented slugs are
+# used here to avoid silently breaking the config.
+issueRules:
+  malware: true
+  installScripts: true
+  didYouMean: true     # typosquats
+  gitDependency: true
+  telemetry: false     # noisy for a crypto/blockchain dep tree; left to the dashboard
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  # Do NOT list the mirror-sync bot here: its automated PRs are exactly what we scan.
+  ignoreUsers: []

--- a/socket.yml
+++ b/socket.yml
@@ -17,7 +17,7 @@ triggerPaths:
   - '**/package.json'
   - '**/package-lock.json'
   - '**/pyproject.toml'
-  - '**/requirements.txt'
+  - '**/*requirements*.txt'   # requirements.txt, dev_requirements.txt, lint_requirements.txt
   - '**/poetry.lock'
   - '**/Cargo.toml'
   - '**/Cargo.lock'


### PR DESCRIPTION
## What & why

This public republish mirror ingests upstream `symbol/symbol` dependencies daily
(`mirror-sync.yml`) and publishes `@nemtus/symbol-sdk` / `@nemtus/symbol-openapi`
to npm via OIDC — today with **no dependency / supply-chain scanning**. This PR adds
layered [Socket](https://socket.dev) protection at **zero cost** (Socket is free and
unlimited for public/open-source repos; Socket Firewall: Free needs no account or API
key; public-repo Actions minutes are free).

## Three layers

1. **Socket GitHub App — PR-time scanning (all ecosystems).** `socket.yml` (repo root)
   scopes scanning to every dependency manifest: npm, Python, Rust, and C/C++
   (`client/catapult/conanfile.py`, `vcpkg.json`). The daily `mirror-sync` PR is
   intentionally **not** ignored, so upstream-introduced risks surface before merge.
2. **Socket Firewall (`sfw`) — install-time hard gate in CI.** Every `npm ci` in
   `mirror-ci.yml`, `publish.yml`, and `openapi-publish.yml` runs as `sfw npm ci`, so a
   confirmed-malicious package fails the install — and the job — before it can build or
   publish. `sfw` is installed via Socket's official action **pinned to a commit SHA**
   (`SocketDev/action@… # v1.3.2`, `mode: firewall-free`); `pinact.yml` enforces the pin
   and Dependabot keeps it current — no hand-edited version string.
3. **Required status check — merge-time hard gate (all ecosystems, incl. C++).** Enabled
   via branch protection (manual, see below).

## Mirror-safe by construction

- `socket.yml` and `.github/dependabot.yml` are **owned by `apply-nemtus-patch.sh`**,
  rewritten verbatim on every sync, so they survive upstream merges; `mirror-ci.yml`'s
  no-drift check enforces byte-identity.
- `.github/dependabot.yml` is scoped to **github-actions only** (keeps SHA-pinned actions
  current, incl. the Socket gate) — it does **not** open npm/cargo PRs that would diverge
  the mirror from upstream. This replaces the previous blanket Dependabot strip.
- Only existing allow-listed workflows are edited; no new workflow file (which a sync
  would strip).

## Coverage / known limit

| Ecosystem | PR scan (App) | Required gate | Install-time block (`sfw`) |
|---|---|---|---|
| npm | ✅ | ✅ | ✅ `sfw npm ci` in CI |
| Python / Rust | ✅ | ✅ | local/Jenkins (`sfw pip/cargo …`) |
| C/C++ | ✅ | ✅ | ✗ `sfw` has no Conan/vcpkg support — covered by layers 1 & 3 |

## One-time manual setup (no code, $0)

- [x] Install the **Socket GitHub App** on `nemtus/symbol` (Marketplace, public = free).
- [x] Add the **Socket check as a required status check** on `dev` (after confirming the
  dashboard alert policy doesn't block on benign alerts, e.g. native code in crypto deps).
- [ ] Confirm **Dependabot is enabled** (default-on for public repos).

See `.github/SUPPLY-CHAIN-SECURITY.md` for the full rationale, local `sfw` usage, and limits.

## Verification done locally

- `apply-nemtus-patch.sh` is idempotent on the current `dev` tree → `git diff --exit-code`
  clean (mirror-ci `verify-rename-layer` will pass); no conflict markers.
- All changed YAML parses; all 8 `SocketDev/action` refs are SHA-pinned (`# v1.3.2`).
- Rebased onto current `dev` (`4d6f21e44`); changes are disjoint from the latest upstream
  sync (devDependency bumps only) — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated supply-chain security scanning to detect and prevent malicious dependencies from being installed during builds and CI/CD operations.

* **Documentation**
  * Added comprehensive supply-chain security hardening guide documenting setup procedures, configuration options, and known limitations.

* **Chores**
  * Updated CI/CD workflows with dependency scanning integration and configured automated dependency update management across all build jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->