### PR TITLE
feat(rest): publish symbol-rest image to GHCR with automated LGPL gate

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -29,7 +29,7 @@ openapi_dir="${repo_root}/openapi"
 readme="${repo_root}/README.md"
 
 # nemtus-owned GitHub workflows that must survive the strip below.
-nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml')
+nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml')
 
 echo "==> patching ${pkg_dir}/package.json"
 cd "${pkg_dir}"

--- a/.github/workflows/rest-image.yml
+++ b/.github/workflows/rest-image.yml
@@ -9,14 +9,16 @@ name: rest-image (build / publish)
 # .github/scripts/apply-nemtus-patch.sh, so mirror-sync does NOT strip it. If you
 # rename this file, update that allow-list too (mirror-ci enforces no-drift).
 #
-# Supply-chain posture: we deliberately use NO third-party marketplace actions here
-# (only the already-pinned actions/checkout). The build runs via the runner's
-# preinstalled `docker buildx`, with SBOM + provenance attestations attached on publish.
+# Supply-chain posture: NO third-party marketplace actions (only the already-pinned
+# actions/checkout); the build runs via the runner's preinstalled `docker buildx`.
+# Least privilege: the `build` job (which runs on PRs, i.e. on untrusted mirror-sync
+# input) is `contents: read` only. `packages: write` lives solely in the `publish` job,
+# which runs only on a release tag / dispatch-with-push.
 #
 # Triggers:
-#   - pull_request touching client/rest -> build + smoke-test ONLY (never pushes).
-#   - push of a tag `rest-image-v*` -> build + PUBLISH to GHCR (+ SBOM/provenance).
-#   - workflow_dispatch -> build; push only when `push=true` is selected.
+#   - pull_request touching client/rest -> build + smoke-test ONLY (read-only token).
+#   - push of a tag `rest-image-v*` -> publish to GHCR (+ SBOM/provenance).
+#   - workflow_dispatch -> build (push=false) or publish (push=true).
 #
 # Publishing posture: symbol-rest is published as a PUBLIC image. The license-scope gate
 # is automated and the evidence is recorded automatically — no per-release manual step
@@ -47,58 +49,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Build + smoke test only. Read-only token (NO packages:write), so a malicious PR
+  # cannot reach the registry. Runs on PRs and on a dispatch that is not publishing.
   build:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.push != true)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # only used by the push step below
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/symbol-rest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # This workflow authenticates to GHCR with GITHUB_TOKEN via docker login,
-          # not git, so don't persist credentials into the local git config.
           persist-credentials: false
 
       # Licensing gate: fail if the source carries any Tech Bureau Commercial-licensed
-      # file (dual-license clause in client/rest/LICENSE.txt). On a PR this is just a
-      # visible red check (keep it OUT of the dev branch-protection required checks so it
-      # never blocks the verbatim SDK mirror sync); on a publish run it runs BEFORE the
-      # push steps, so a failure here makes publishing a non-LGPL image impossible.
+      # file (dual-license clause in client/rest/LICENSE.txt). Keep this OUT of the dev
+      # branch-protection required checks so it never blocks the verbatim SDK mirror sync.
       - name: License-scope check (no commercial-licensed files)
         run: bash client/rest/scripts/check-license-scope.sh
 
-      - name: Decide push + tags
-        id: meta
-        run: |
-          push=false
-          if [ "${{ github.event_name }}" = "push" ]; then push=true; fi
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.push }}" = "true" ]; then push=true; fi
-          echo "push=${push}" >> "$GITHUB_OUTPUT"
-
-          ref="${{ github.ref_name }}"
-          version="${ref#rest-image-}"   # tag rest-image-v2.5.1 -> v2.5.1
-          sha="$(git rev-parse --short HEAD)"
-          echo "vcs_ref=${sha}" >> "$GITHUB_OUTPUT"
-          tags="${IMAGE}:sha-${sha}"
-          if [ "${{ github.event_name }}" = "push" ]; then tags="${tags},${IMAGE}:${version},${IMAGE}:latest"; fi
-          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up buildx (docker-container driver for registry cache)
+      - name: Set up buildx
         run: docker buildx create --use --name nemtus --driver docker-container
 
-      - name: Log in to GHCR
-        if: steps.meta.outputs.push == 'true'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      # PR / non-push: build and load locally so we can smoke-test the artifact.
       - name: Build (verify, no push)
-        if: steps.meta.outputs.push != 'true'
         run: |
+          sha="$(git rev-parse --short HEAD)"
           docker buildx build \
             -f client/rest/Dockerfile.nemtus \
-            --build-arg "VCS_REF=${{ steps.meta.outputs.vcs_ref }}" \
+            --build-arg "VCS_REF=${sha}" \
+            --build-arg "IMAGE_VERSION=${{ github.ref_name }}" \
             --cache-from "type=registry,ref=${IMAGE}:buildcache" \
             -t "${IMAGE}:ci" \
             --load \
@@ -107,22 +87,53 @@ jobs:
       # The backends (MongoDB / catapult API node / broker) aren't available in CI, so
       # the smoke test syntax-loads each entrypoint and confirms the licenses are bundled.
       - name: Smoke test (entrypoints load, licenses bundled)
-        if: steps.meta.outputs.push != 'true'
         run: |
           docker run --rm "${IMAGE}:ci" --check src/index.js
           docker run --rm "${IMAGE}:ci" --check src/index.light.js
           docker run --rm "${IMAGE}:ci" --check src/index.rosetta.js
           docker run --rm --entrypoint sh "${IMAGE}:ci" -c 'ls /app/licenses && test -f /app/THIRD_PARTY_NOTICES.md'
 
-      # Release tag / dispatch-with-push: publish to GHCR with SBOM + provenance, and
-      # warm the registry build cache. The in-Dockerfile license-scope gate also runs
-      # here, so a non-LGPL tree cannot produce a pushed image.
+  # Publish to GHCR. The ONLY job with packages:write, and only on a tag push or a
+  # dispatch with push=true. The license-scope gate runs again here (and inside the
+  # Dockerfile), so a non-LGPL tree cannot produce a published image.
+  publish:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/symbol-rest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: License-scope check (no commercial-licensed files)
+        run: bash client/rest/scripts/check-license-scope.sh
+
+      - name: Decide tags
+        id: meta
+        run: |
+          ref="${{ github.ref_name }}"
+          version="${ref#rest-image-}"   # tag rest-image-v2.5.1 -> v2.5.1
+          sha="$(git rev-parse --short HEAD)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "vcs_ref=${sha}" >> "$GITHUB_OUTPUT"
+          echo "tags=${IMAGE}:sha-${sha},${IMAGE}:${version},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Set up buildx
+        run: docker buildx create --use --name nemtus --driver docker-container
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
       - name: Build and publish (GHCR)
-        if: steps.meta.outputs.push == 'true'
         run: |
           docker buildx build \
             -f client/rest/Dockerfile.nemtus \
             --build-arg "VCS_REF=${{ steps.meta.outputs.vcs_ref }}" \
+            --build-arg "IMAGE_VERSION=${{ steps.meta.outputs.version }}" \
             --cache-from "type=registry,ref=${IMAGE}:buildcache" \
             --cache-to "type=registry,ref=${IMAGE}:buildcache,mode=max" \
             --provenance=true --sbom=true \
@@ -132,7 +143,6 @@ jobs:
             client/rest
 
       - name: Record publish evidence
-        if: steps.meta.outputs.push == 'true'
         run: |
           digest="$(jq -r '."containerimage.digest" // "unknown"' /tmp/build-meta.json 2>/dev/null || echo unknown)"
           {
@@ -150,7 +160,6 @@ jobs:
           echo "::notice::Published ${IMAGE} @ ${digest}"
 
       - name: Package-visibility reminder (one-time)
-        if: steps.meta.outputs.push == 'true'
         run: |
           echo "::notice::If ghcr.io/${{ github.repository_owner }}/symbol-rest is still PRIVATE,"
           echo "::notice::set it to Public once in the package settings (the org must also allow public packages);"

--- a/.github/workflows/rest-image.yml
+++ b/.github/workflows/rest-image.yml
@@ -1,0 +1,157 @@
+name: rest-image (build / publish)
+
+# Nemtus-owned workflow that builds the client/rest (symbol-api-rest) container image
+# from client/rest/Dockerfile.nemtus and, on a release tag, publishes it to GHCR as
+# ghcr.io/nemtus/symbol-rest. This mirrors the upstream client/rest build (Ubuntu +
+# Node from NodeSource, `npm install --omit=dev`) plus the nemtus publishing layer.
+#
+# IMPORTANT (mirror): this workflow is in the `nemtus_workflows` allow-list in
+# .github/scripts/apply-nemtus-patch.sh, so mirror-sync does NOT strip it. If you
+# rename this file, update that allow-list too (mirror-ci enforces no-drift).
+#
+# Supply-chain posture: we deliberately use NO third-party marketplace actions here
+# (only the already-pinned actions/checkout). The build runs via the runner's
+# preinstalled `docker buildx`, with SBOM + provenance attestations attached on publish.
+#
+# Triggers:
+#   - pull_request touching client/rest -> build + smoke-test ONLY (never pushes).
+#   - push of a tag `rest-image-v*` -> build + PUBLISH to GHCR (+ SBOM/provenance).
+#   - workflow_dispatch -> build; push only when `push=true` is selected.
+#
+# Publishing posture: symbol-rest is published as a PUBLIC image. The license-scope gate
+# is automated and the evidence is recorded automatically — no per-release manual step
+# while the gate is green. See client/rest/docs/PUBLISHING-COMPLIANCE.md. GHCR package
+# visibility is a ONE-TIME setup (first publish creates a private package; flip it to
+# public once — the org must also allow public packages — then releases stay public).
+
+on:
+  pull_request:
+    paths:
+      - 'client/rest/**'
+      - '.github/workflows/rest-image.yml'
+  push:
+    tags:
+      - 'rest-image-v*'
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Publish the image to GHCR'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rest-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # only used by the push step below
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/symbol-rest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # This workflow authenticates to GHCR with GITHUB_TOKEN via docker login,
+          # not git, so don't persist credentials into the local git config.
+          persist-credentials: false
+
+      # Licensing gate: fail if the source carries any Tech Bureau Commercial-licensed
+      # file (dual-license clause in client/rest/LICENSE.txt). On a PR this is just a
+      # visible red check (keep it OUT of the dev branch-protection required checks so it
+      # never blocks the verbatim SDK mirror sync); on a publish run it runs BEFORE the
+      # push steps, so a failure here makes publishing a non-LGPL image impossible.
+      - name: License-scope check (no commercial-licensed files)
+        run: bash client/rest/scripts/check-license-scope.sh
+
+      - name: Decide push + tags
+        id: meta
+        run: |
+          push=false
+          if [ "${{ github.event_name }}" = "push" ]; then push=true; fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.push }}" = "true" ]; then push=true; fi
+          echo "push=${push}" >> "$GITHUB_OUTPUT"
+
+          ref="${{ github.ref_name }}"
+          version="${ref#rest-image-}"   # tag rest-image-v2.5.1 -> v2.5.1
+          sha="$(git rev-parse --short HEAD)"
+          echo "vcs_ref=${sha}" >> "$GITHUB_OUTPUT"
+          tags="${IMAGE}:sha-${sha}"
+          if [ "${{ github.event_name }}" = "push" ]; then tags="${tags},${IMAGE}:${version},${IMAGE}:latest"; fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up buildx (docker-container driver for registry cache)
+        run: docker buildx create --use --name nemtus --driver docker-container
+
+      - name: Log in to GHCR
+        if: steps.meta.outputs.push == 'true'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # PR / non-push: build and load locally so we can smoke-test the artifact.
+      - name: Build (verify, no push)
+        if: steps.meta.outputs.push != 'true'
+        run: |
+          docker buildx build \
+            -f client/rest/Dockerfile.nemtus \
+            --build-arg "VCS_REF=${{ steps.meta.outputs.vcs_ref }}" \
+            --cache-from "type=registry,ref=${IMAGE}:buildcache" \
+            -t "${IMAGE}:ci" \
+            --load \
+            client/rest
+
+      # The backends (MongoDB / catapult API node / broker) aren't available in CI, so
+      # the smoke test syntax-loads each entrypoint and confirms the licenses are bundled.
+      - name: Smoke test (entrypoints load, licenses bundled)
+        if: steps.meta.outputs.push != 'true'
+        run: |
+          docker run --rm "${IMAGE}:ci" --check src/index.js
+          docker run --rm "${IMAGE}:ci" --check src/index.light.js
+          docker run --rm "${IMAGE}:ci" --check src/index.rosetta.js
+          docker run --rm --entrypoint sh "${IMAGE}:ci" -c 'ls /app/licenses && test -f /app/THIRD_PARTY_NOTICES.md'
+
+      # Release tag / dispatch-with-push: publish to GHCR with SBOM + provenance, and
+      # warm the registry build cache. The in-Dockerfile license-scope gate also runs
+      # here, so a non-LGPL tree cannot produce a pushed image.
+      - name: Build and publish (GHCR)
+        if: steps.meta.outputs.push == 'true'
+        run: |
+          docker buildx build \
+            -f client/rest/Dockerfile.nemtus \
+            --build-arg "VCS_REF=${{ steps.meta.outputs.vcs_ref }}" \
+            --cache-from "type=registry,ref=${IMAGE}:buildcache" \
+            --cache-to "type=registry,ref=${IMAGE}:buildcache,mode=max" \
+            --provenance=true --sbom=true \
+            --metadata-file /tmp/build-meta.json \
+            $(printf -- '-t %s ' $(echo "${{ steps.meta.outputs.tags }}" | tr ',' ' ')) \
+            --push \
+            client/rest
+
+      - name: Record publish evidence
+        if: steps.meta.outputs.push == 'true'
+        run: |
+          digest="$(jq -r '."containerimage.digest" // "unknown"' /tmp/build-meta.json 2>/dev/null || echo unknown)"
+          {
+            echo "## symbol-rest image published"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| tags | \`${{ steps.meta.outputs.tags }}\` |"
+            echo "| digest | \`${digest}\` |"
+            echo "| source revision | \`${{ steps.meta.outputs.vcs_ref }}\` (\`${{ github.sha }}\`) |"
+            echo "| license-scope gate | PASSED (also bundled in image at /app/licenses/LICENSE-SCOPE-REPORT.txt) |"
+            echo "| attestations | SBOM + SLSA provenance attached via buildx |"
+            echo "| run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice::Published ${IMAGE} @ ${digest}"
+
+      - name: Package-visibility reminder (one-time)
+        if: steps.meta.outputs.push == 'true'
+        run: |
+          echo "::notice::If ghcr.io/${{ github.repository_owner }}/symbol-rest is still PRIVATE,"
+          echo "::notice::set it to Public once in the package settings (the org must also allow public packages);"
+          echo "::notice::later releases stay public automatically."

--- a/client/rest/Dockerfile.nemtus
+++ b/client/rest/Dockerfile.nemtus
@@ -56,6 +56,8 @@ FROM ubuntu:${UBUNTU_VERSION} AS runtime
 ARG NODE_MAJOR
 ARG DEBIAN_FRONTEND=noninteractive
 ARG VCS_REF=unknown
+# Release version for image.version (e.g. v2.5.1 on a tag build); VCS_REF stays the commit.
+ARG IMAGE_VERSION=unknown
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg ca-certificates \
     && mkdir -p /etc/apt/keyrings \
@@ -74,7 +76,7 @@ LABEL org.opencontainers.image.title="symbol-rest" \
       org.opencontainers.image.source="https://github.com/nemtus/symbol" \
       org.opencontainers.image.url="https://github.com/nemtus/symbol/tree/dev/client/rest" \
       org.opencontainers.image.revision="${VCS_REF}" \
-      org.opencontainers.image.version="${VCS_REF}" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
       org.opencontainers.image.licenses="LGPL-3.0-or-later" \
       org.opencontainers.image.documentation="https://github.com/nemtus/symbol/blob/dev/client/rest/docs/PUBLISHING-COMPLIANCE.md"
 

--- a/client/rest/Dockerfile.nemtus
+++ b/client/rest/Dockerfile.nemtus
@@ -1,0 +1,93 @@
+# syntax=docker/dockerfile:1.7
+#
+# Nemtus-owned image for client/rest (symbol-api-rest), published to GHCR as
+# ghcr.io/nemtus/symbol-rest by .github/workflows/rest-image.yml.
+#
+# This mirrors the upstream client/rest/Dockerfile build (Ubuntu + Node from
+# NodeSource, `npm install --omit=dev`) and adds the nemtus publishing layer:
+#   - a license-scope gate (defense in depth) that fails the build on any Tech Bureau
+#     Commercial-licensed file and bundles its PASS report into the image,
+#   - OCI image labels (source / revision / licenses) for LGPL-3.0 redistribution,
+#   - a default ENTRYPOINT so the image is runnable out of the box.
+#
+# We keep this SEPARATE from the upstream client/rest/Dockerfile (which mirror-sync
+# overwrites) so the nemtus layer survives upstream syncs. If upstream bumps the Node
+# major or base image, update this file to match.
+#
+# Build context is client/rest (the same as the upstream Dockerfile).
+# For production pin the base by digest, e.g. `FROM ubuntu:24.04@sha256:<digest>`.
+
+ARG UBUNTU_VERSION=24.04
+ARG NODE_MAJOR=24
+
+############################ Stage 1: builder ############################
+FROM ubuntu:${UBUNTU_VERSION} AS builder
+ARG NODE_MAJOR
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg ca-certificates \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Licensing gate (defense in depth + automatic in-image evidence): the image cannot
+# be built from a tree containing Tech Bureau Commercial-licensed files. The PASS
+# report travels with the image as proof the gate held at build time. Runs BEFORE
+# `npm install` so a source-scope violation fails fast.
+RUN set -eu; mkdir -p /app/licenses; \
+    if bash scripts/check-license-scope.sh > /app/licenses/LICENSE-SCOPE-REPORT.txt 2>&1; then \
+        cat /app/licenses/LICENSE-SCOPE-REPORT.txt; \
+    else \
+        cat /app/licenses/LICENSE-SCOPE-REPORT.txt; exit 1; \
+    fi
+
+# Production dependencies only. Each package keeps its own LICENSE under node_modules,
+# so the image is self-describing; the published image also carries an SBOM attestation.
+RUN npm install --omit=dev
+
+############################ Stage 2: runtime ############################
+FROM ubuntu:${UBUNTU_VERSION} AS runtime
+ARG NODE_MAJOR
+ARG DEBIAN_FRONTEND=noninteractive
+ARG VCS_REF=unknown
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl gnupg ca-certificates \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Provenance / licensing metadata. image.source + image.revision give the
+# corresponding-source pointer required for LGPL-3.0 redistribution; the third-party
+# inventory is at /app/THIRD_PARTY_NOTICES.md and the bundled license texts under /app.
+LABEL org.opencontainers.image.title="symbol-rest" \
+      org.opencontainers.image.description="Symbol REST API gateway (catapult-rest / symbol-api-rest)" \
+      org.opencontainers.image.vendor="nemtus" \
+      org.opencontainers.image.source="https://github.com/nemtus/symbol" \
+      org.opencontainers.image.url="https://github.com/nemtus/symbol/tree/dev/client/rest" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VCS_REF}" \
+      org.opencontainers.image.licenses="LGPL-3.0-or-later" \
+      org.opencontainers.image.documentation="https://github.com/nemtus/symbol/blob/dev/client/rest/docs/PUBLISHING-COMPLIANCE.md"
+
+# Numeric USER avoids coupling to the image's default user name (ubuntu, UID 1000).
+USER 1000
+WORKDIR /app
+COPY --chown=1000:1000 --from=builder /app .
+
+EXPOSE 3000
+
+# Default runs the full REST gateway (needs MongoDB + a catapult API node + broker).
+# ENTRYPOINT is `node`, so override the script for the light / rosetta variants:
+#   docker run --rm <image> src/index.light.js
+#   docker run --rm <image> src/index.rosetta.js
+ENTRYPOINT ["node"]
+CMD ["src/index.js"]

--- a/client/rest/THIRD_PARTY_NOTICES.md
+++ b/client/rest/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,61 @@
+# Third-Party Notices — symbol-rest image
+
+This file inventories the licenses of what is bundled in the container image built
+from `client/rest/Dockerfile.nemtus`. It is provided to support redistribution of that
+image. It is informational and not legal advice; see `docs/PUBLISHING-COMPLIANCE.md`
+for the publishing checklist.
+
+## 1. symbol-rest (the primary work)
+
+- **License:** GNU Lesser General Public License v3.0 or later (`LGPL-3.0-or-later`).
+  Full text bundled at `/app/COPYING.LESSER` (and `/app/LICENSE.txt`).
+- **Dual-licensing note:** Per `LICENSE.txt`, source files are LGPL-3.0 *unless a file
+  header or a directory `LICENSE` declares the Tech Bureau Commercial License*. The
+  image is intended to contain **only LGPL-3.0 sources**; this is enforced by
+  `scripts/check-license-scope.sh` (its PASS report is bundled at
+  `/app/licenses/LICENSE-SCOPE-REPORT.txt`).
+- **Corresponding source (LGPL requirement):** the exact revision is published at
+  <https://github.com/nemtus/symbol> and recorded in the image's
+  `org.opencontainers.image.revision` label.
+- **Copyright:** © Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp. and contributors.
+
+## 2. Generated code bundled in the source tree
+
+| Path | Origin | License |
+|------|--------|---------|
+| `src/plugins/rosetta/openApi/**` | generated client from the Rosetta API OpenAPI spec | Apache-2.0 (Rosetta spec © Coinbase) |
+
+`src/plugins/metadata/metal.js` is nemtus/upstream rest code that ships without a
+license header; it is LGPL-3.0 like the rest of `src/`.
+
+## 3. npm production dependencies
+
+The image bundles the production dependency tree (`npm install --omit=dev`) under
+`/app/node_modules`. These are third-party packages (e.g. `fastify`, `mongodb`,
+`zeromq`, `ws`, `symbol-sdk`, `winston`, …) under their own, predominantly permissive
+licenses (MIT / Apache-2.0 / ISC / BSD). **Each package keeps its own `LICENSE` file
+under `/app/node_modules/<pkg>/`**, and the published image additionally carries an
+**SBOM attestation** (attached by buildx) enumerating every package and version. No
+hand-maintained aggregate is kept, to avoid drift from the (large, transitive) tree.
+
+## 4. Base image (Ubuntu + Node.js) runtime components
+
+The runtime stage is `ubuntu:24.04` plus `nodejs` from NodeSource and their transitive
+runtime libraries (glibc = LGPL-2.1-or-later, libstdc++/libgcc = GPL-3.0-or-later WITH
+GCC-Runtime-Library-exception-3.1, `ca-certificates`, `openssl` = Apache-2.0, …). These
+are unmodified distribution packages; corresponding source is available from Canonical
+(<https://ubuntu.com/legal/open-source-licences>) and NodeSource / the Node.js project.
+
+## 5. Written offer for source
+
+For the copyleft components above (symbol-rest LGPL-3.0 and the Ubuntu GPL/LGPL runtime
+libraries), the complete corresponding source can be obtained from each project's
+upstream and, for symbol-rest specifically, from <https://github.com/nemtus/symbol> at
+the commit named in the image's `org.opencontainers.image.revision` label. Requests may
+also be directed to the nemtus maintainers via <https://github.com/nemtus/symbol/issues>.
+
+## 6. Trademarks
+
+"Symbol", "NEM" and related names/logos are the property of their respective owners.
+The LGPL grants no trademark rights; this image is an independent build and is not
+endorsed by or affiliated with the upstream project owners.

--- a/client/rest/docs/PUBLISHING-COMPLIANCE.md
+++ b/client/rest/docs/PUBLISHING-COMPLIANCE.md
@@ -1,0 +1,141 @@
+# Publishing-compliance — symbol-rest image
+
+symbol-rest is **published as a public container image** (`ghcr.io/nemtus/symbol-rest`)
+from `client/rest/Dockerfile.nemtus`. Compliance is enforced and evidenced
+**automatically** by CI/CD — while the gate is green there is **no per-release manual
+step**. It is engineering guidance, **not legal advice**; because a third party
+(Tech Bureau, Corp.) holds copyright and the source is dual-licensed, the automated
+`check-license-scope.sh` gate (Section 1) is the agreed, recorded standard that no
+commercial-licensed code is shipped.
+
+**How it is automated (no manual work on the green path):**
+1. `check-license-scope.sh` runs as a CI step **and** inside the Dockerfile, hard-blocking
+   any build/publish if a commercial-licensed file appears (Section 1).
+2. The PASS report is bundled in the image at `/app/licenses/LICENSE-SCOPE-REPORT.txt`,
+   and an SBOM + SLSA provenance attestation is attached to the published image.
+3. `.github/workflows/rest-image.yml` records revision + image digest + gate result to
+   the workflow run summary on every publish.
+
+A human is needed **only** in the exception case where the gate fails — then publishing
+is blocked and Section 6/7 apply.
+
+## 1. The licensing gate (the only blocker)
+
+`client/rest/LICENSE.txt` states each source file is **LGPL-3.0** *unless its header or a
+directory `LICENSE` declares the **Tech Bureau Commercial License***. Publishing is only
+permissible if the shipped source contains **no commercial-licensed file**.
+
+Verify with the single source-of-truth scanner (also run by
+`.github/workflows/rest-image.yml`, where it hard-blocks publishing on failure):
+
+```sh
+bash client/rest/scripts/check-license-scope.sh
+```
+
+It checks three things and exits non-zero on any finding: (1) no directory-level LICENSE
+other than the root `COPYING.LESSER`/`LICENSE.txt` (node_modules excluded); (2) no
+`src/**/*.js` contains `tech bureau commercial`/`commercial license`/`proprietary`/
+`confidential`; (3) every `src/**/*.js` carries the LGPL header, except the allowlisted
+generated Rosetta client (`src/plugins/rosetta/openApi/**`, Apache-2.0) and
+`src/plugins/metadata/metal.js` (headerless rest code). As of the last check this tree is
+**all LGPL-3.0** (0 commercial-licensed files). Re-run on the exact revision being
+published — the dual-license clause means commercial files *could* appear after a sync.
+
+- [ ] `check-license-scope.sh` re-run on the exact revision being published; output recorded.
+- [ ] `resources/` reviewed (config templates; data, not commercial-licensed code).
+
+## 2. LGPL-3.0 obligations (mechanical — already wired into the image)
+
+- [x] LGPL text shipped in image at `/app/COPYING.LESSER` (and `/app/LICENSE.txt`).
+- [x] `THIRD_PARTY_NOTICES.md` shipped at `/app/` and the gate report at `/app/licenses/`.
+- [x] Corresponding-source pointer: `org.opencontainers.image.source` +
+      `org.opencontainers.image.revision` labels point at the public nemtus commit.
+- [ ] Confirm the published revision is actually pushed/public on `github.com/nemtus/symbol`.
+- [ ] Any nemtus modifications to rest source are disclosed under LGPL in that fork.
+- Relinking clause: satisfied — rest is shipped as its own LGPL work (interpreted by an
+  unmodified Node.js runtime) with public source; no proprietary combination.
+
+## 3. Bundled-dependency notices
+
+- [x] `THIRD_PARTY_NOTICES.md` covers rest (LGPL-3.0), the generated Rosetta client
+      (Apache-2.0), the npm production tree, and the Ubuntu/Node base.
+- [x] npm production dependencies bundle each package's own `LICENSE` under
+      `/app/node_modules/<pkg>/`; the published image also carries an SBOM attestation.
+
+## 4. Trademark
+
+- [ ] Image named neutrally (`ghcr.io/nemtus/symbol-rest`); no use of Symbol/NEM logos;
+      no implication of official endorsement. (Notice present in THIRD_PARTY_NOTICES.)
+
+## 5. Provenance (recommended, not strictly required)
+
+- [ ] Base image pinned by digest in `Dockerfile.nemtus`.
+- [ ] SBOM generated and attached (the publish workflow emits one).
+- [ ] Image signed (cosign keyless) — left as a follow-up to avoid an unpinned action.
+
+## 6. Green path (automated) and the one-time setup
+
+**Green path — no manual step.** Pushing a `rest-image-v*` tag runs the publish workflow,
+which: runs the license-scope gate, builds the image (the gate runs again inside the
+Dockerfile), publishes it to GHCR with SBOM + provenance, and records the evidence
+(revision, digest, gate result) to the run summary. If the gate is green, that is the
+complete, recorded compliance evidence — nothing to sign by hand.
+
+**One-time setup (first publish only).** GHCR creates a *private* package on the first
+push. Flip it to public once (package settings → Change visibility → Public; optionally
+link it to this repo). Note: the **organization** must also allow public packages
+(Org settings → Packages), otherwise the package-level control is disabled. Every later
+release then stays public automatically. The workflow does NOT change visibility itself.
+
+**Exception path — the gate failed.** If `check-license-scope.sh` reports findings (e.g.
+an upstream sync introduced a Tech Bureau Commercial-licensed file), the build and publish
+are blocked automatically. Resolving it is a human decision: review the findings, and
+either exclude the offending files from the build or stop publishing that revision.
+Record that decision with the template in Section 7. The green path never needs it.
+
+## 7. Exception sign-off record (template — only when the gate flags something)
+
+> Use this ONLY when Section 1's gate failed and a human decided how to proceed. The
+> normal green path is evidenced automatically (Section 6) and needs no manual record.
+> Copy this block into the release PR / issue and fill in every `<...>`.
+
+```markdown
+## symbol-rest image — publishing sign-off
+
+- Image tag(s):     <e.g. ghcr.io/nemtus/symbol-rest:v2.5.1>
+- Image digest:     <sha256:... from `docker buildx imagetools inspect` after push>
+- Source revision:  <full git commit on github.com/nemtus/symbol — matches image.revision label>
+- Base image:       <ubuntu:24.04@sha256:... pinned digest>
+- Date:             <YYYY-MM-DD>
+
+### Evidence (attach command output)
+- [ ] `bash client/rest/scripts/check-license-scope.sh` PASSED on THIS revision
+      → output: <paste the RESULT line + any findings>
+- [ ] `resources/` reviewed — no non-LGPL / commercial payload: <notes>
+- [ ] Source revision is public on github.com/nemtus/symbol: <link to commit>
+- [ ] Image bundles licenses: `/app/{COPYING.LESSER,LICENSE.txt,THIRD_PARTY_NOTICES.md}`
+      and `/app/licenses/LICENSE-SCOPE-REPORT.txt`
+      `docker run --rm --entrypoint ls <image> /app/licenses` → <paste>
+- [ ] THIRD_PARTY_NOTICES.md complete (rest + Rosetta + npm tree + base): <confirmed>
+
+### Legal review
+- Reviewer:         <name / "legal counsel" / "N/A — rationale">
+- Outcome:          <approved | changes required>
+- Notes:            <...>
+
+### Decision
+- [ ] APPROVED to publish (make GHCR package public)
+- Approver (name):  <name>
+- Role / authority: <e.g. NEMTUS maintainer authorised to accept this risk>
+- Date:             <YYYY-MM-DD>
+- Signature:        <name / git handle>
+```
+
+After this record is completed and approved, change the GHCR package visibility to public
+manually (Package settings → Danger Zone → Change visibility). The CI workflow never does
+this automatically.
+
+## References
+- `client/rest/LICENSE.txt`, `client/rest/COPYING.LESSER`
+- `client/rest/THIRD_PARTY_NOTICES.md`
+- `client/rest/Dockerfile.nemtus`, `.github/workflows/rest-image.yml`

--- a/client/rest/scripts/build-docker-rest.sh
+++ b/client/rest/scripts/build-docker-rest.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Build the nemtus symbol-rest Docker image (client/rest/Dockerfile.nemtus).
+#
+# The build context is client/rest (the same as the upstream Dockerfile). The image
+# runs the license-scope gate at build time and bundles the result + license texts.
+#
+# Usage:
+#   client/rest/scripts/build-docker-rest.sh
+#
+# Environment overrides:
+#   IMAGE           image tag to build        (default: nemtus/symbol-rest:local)
+#   UBUNTU_VERSION  base ubuntu image version (default: image default, 24.04)
+#   NODE_MAJOR      Node.js major version     (default: image default, 24)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"        # client/rest
+REPO_ROOT="$(cd "${REST_DIR}/../.." && pwd)"      # repo root (for the VCS ref)
+
+IMAGE="${IMAGE:-nemtus/symbol-rest:local}"
+
+# Provenance: the image records the exact source revision in its OCI image.revision
+# label. Derive it from the host checkout; mark a dirty working tree so an image built
+# from uncommitted changes is not mistaken for a clean commit.
+VCS_REF="$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if ! git -C "${REPO_ROOT}" diff --quiet HEAD 2>/dev/null; then
+	VCS_REF="${VCS_REF}-dirty"
+fi
+
+build_args=(--build-arg "VCS_REF=${VCS_REF}")
+[[ -n "${UBUNTU_VERSION:-}" ]] && build_args+=(--build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}")
+[[ -n "${NODE_MAJOR:-}" ]] && build_args+=(--build-arg "NODE_MAJOR=${NODE_MAJOR}")
+
+echo "[*] context : ${REST_DIR}"
+echo "[*] image   : ${IMAGE}"
+echo "[*] vcs ref : ${VCS_REF}"
+
+cd "${REST_DIR}"
+DOCKER_BUILDKIT=1 docker build \
+	-f Dockerfile.nemtus \
+	-t "${IMAGE}" \
+	"${build_args[@]}" \
+	.
+
+echo "[*] done. verify the image with:"
+echo "    docker run --rm ${IMAGE} --check src/index.js          # syntax-load the entrypoint"
+echo "    docker run --rm --entrypoint sh ${IMAGE} -c 'ls /app/licenses'"

--- a/client/rest/scripts/build-docker-rest.sh
+++ b/client/rest/scripts/build-docker-rest.sh
@@ -29,7 +29,7 @@ if ! git -C "${REPO_ROOT}" diff --quiet HEAD 2>/dev/null; then
 	VCS_REF="${VCS_REF}-dirty"
 fi
 
-build_args=(--build-arg "VCS_REF=${VCS_REF}")
+build_args=(--build-arg "VCS_REF=${VCS_REF}" --build-arg "IMAGE_VERSION=${IMAGE_VERSION:-local}")
 [[ -n "${UBUNTU_VERSION:-}" ]] && build_args+=(--build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}")
 [[ -n "${NODE_MAJOR:-}" ]] && build_args+=(--build-arg "NODE_MAJOR=${NODE_MAJOR}")
 

--- a/client/rest/scripts/check-license-scope.sh
+++ b/client/rest/scripts/check-license-scope.sh
@@ -43,10 +43,21 @@ else
   echo "  OK: only root COPYING.LESSER + LICENSE.txt"
 fi
 
-echo "== (2) commercial / proprietary markers in src =="
-# NB: 'All rights reserved' is part of the standard LGPL header, so it is NOT a marker.
-markers="$(grep -rilE 'tech bureau commercial|commercial license|proprietary|confidential' \
-  --include='*.js' src || true)"
+echo "== (2) commercial-license markers across the whole shipped tree =="
+# The image ships the entire client/rest tree (COPY . .), so scan it all, not just src.
+# A file placed under the Tech Bureau Commercial License names it (like the LGPL header
+# names the LGPL), so the high-signal phrases below are scanned tree-wide -- EXCEPT the
+# files that legitimately *describe* the dual license rather than being licensed under it.
+# (node_modules holds third-party permissive packages; ./licenses is this gate's report.)
+# 'All rights reserved' is part of the standard LGPL header, so it is NOT a marker; the
+# generic 'proprietary'/'confidential' words appear in upstream docs (CODE_OF_CONDUCT etc.)
+# so they are only applied to src/*.js where they are meaningful and noise-free.
+meta_allow='^\./(LICENSE\.txt|COPYING\.LESSER|THIRD_PARTY_NOTICES\.md|Dockerfile\.nemtus|docs/PUBLISHING-COMPLIANCE\.md|scripts/check-license-scope\.sh)$'
+tree_markers="$(grep -rilE 'tech bureau commercial|commercial license' . \
+    --exclude-dir=node_modules --exclude-dir=licenses --exclude-dir=.git 2>/dev/null \
+  | grep -vE "${meta_allow}" || true)"
+src_markers="$(grep -rilE 'proprietary|confidential' --include='*.js' src 2>/dev/null || true)"
+markers="$(printf '%s\n%s\n' "${tree_markers}" "${src_markers}" | grep -vE '^[[:space:]]*$' | sort -u || true)"
 if [ -n "${markers}" ]; then
   echo "  FAIL: file(s) with commercial/proprietary markers:"
   printf '%s\n' "${markers}" | sed 's/^/    /'

--- a/client/rest/scripts/check-license-scope.sh
+++ b/client/rest/scripts/check-license-scope.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# check-license-scope.sh
+#
+# Verifies that the client/rest source shipped in the image is LGPL-3.0 ONLY (plus
+# known generated / third-party files) and carries NO Tech Bureau Commercial-licensed
+# files. This is the single source of truth for the "licensing gate" in
+# docs/PUBLISHING-COMPLIANCE.md and is run by .github/workflows/rest-image.yml and
+# inside client/rest/Dockerfile.nemtus.
+#
+# client/rest/LICENSE.txt dual-licenses each file (LGPL-3.0 unless a header or a
+# directory LICENSE declares the Tech Bureau Commercial License), so an upstream sync
+# *could* introduce commercial files later. This script is how that is detected.
+#
+# Allowlisted non-LGPL source (not commercial; reviewed):
+#   - src/plugins/rosetta/openApi/**  generated Rosetta OpenAPI client (Coinbase, Apache-2.0)
+#   - src/plugins/metadata/metal.js   rest's own code that ships without a header
+#
+# Exit status:
+#   0 = scope is clean (safe to publish)
+#   1 = something outside the LGPL-3.0 / allowlisted scope was found (do NOT publish)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" # client/rest
+cd "${REST_DIR}"
+
+fail=0
+
+echo "== (1) directory-level LICENSE/COPYING declarations (node_modules/licenses excluded) =="
+# Only the two root files are expected; anything else may declare a separate license.
+# node_modules holds third-party (permissive) packages, and ./licenses is where the
+# Dockerfile writes this gate's own LICENSE-SCOPE-REPORT.txt; both are excluded.
+unexpected="$(find . \( -path ./node_modules -o -path ./licenses \) -prune -o -type f \
+    \( -iname 'LICENSE*' -o -iname 'COPYING*' -o -iname '*.license' \) -print \
+  | grep -vE '^\./(LICENSE\.txt|COPYING\.LESSER)$' || true)"
+if [ -n "${unexpected}" ]; then
+  echo "  FAIL: unexpected license declaration(s):"
+  printf '%s\n' "${unexpected}" | sed 's/^/    /'
+  fail=1
+else
+  echo "  OK: only root COPYING.LESSER + LICENSE.txt"
+fi
+
+echo "== (2) commercial / proprietary markers in src =="
+# NB: 'All rights reserved' is part of the standard LGPL header, so it is NOT a marker.
+markers="$(grep -rilE 'tech bureau commercial|commercial license|proprietary|confidential' \
+  --include='*.js' src || true)"
+if [ -n "${markers}" ]; then
+  echo "  FAIL: file(s) with commercial/proprietary markers:"
+  printf '%s\n' "${markers}" | sed 's/^/    /'
+  fail=1
+else
+  echo "  OK: 0 files"
+fi
+
+echo "== (3) src/*.js without the LGPL header (generated Rosetta client + metal.js allowed) =="
+nonlgpl=""
+while IFS= read -r f; do
+  case "${f}" in
+    ./src/plugins/rosetta/openApi/*) continue ;;
+    ./src/plugins/metadata/metal.js) continue ;;
+  esac
+  if ! grep -qi 'GNU Lesser General Public License' "${f}"; then
+    nonlgpl="${nonlgpl}${f}"$'\n'
+  fi
+done < <(find ./src -type f -name '*.js')
+if [ -n "${nonlgpl}" ]; then
+  echo "  FAIL: non-LGPL src .js outside the allowlist (needs license review):"
+  printf '%s' "${nonlgpl}" | sed 's/^/    /'
+  fail=1
+else
+  echo "  OK: every src .js is LGPL-headed (except the allowlisted generated/headerless files)"
+fi
+
+echo
+if [ "${fail}" -ne 0 ]; then
+  echo "RESULT: license-scope check FAILED."
+  echo "Do NOT publish a symbol-rest image from this revision until the findings are reviewed"
+  echo "(see client/rest/docs/PUBLISHING-COMPLIANCE.md)."
+  exit 1
+fi
+echo "RESULT: license-scope check PASSED — LGPL-3.0 scope only, no commercial-licensed files."


### PR DESCRIPTION
## Summary

Adds the same publishing pipeline used for catapult-server (#33) to `client/rest`,
producing **`ghcr.io/nemtus/symbol-rest`** that tracks the upstream rest version
(currently **2.5.1**), with the LGPL-3.0 compliance gate and evidence automated in CI/CD.
New nemtus layer only — no upstream files modified.

### Why
- We want the rest gateway available as a versioned GHCR image under nemtus, mirroring
  upstream `symbolplatform/symbol-rest` and the catapult-server setup.
- rest is dual-licensed per file (LGPL-3.0 **or** Tech Bureau Commercial), so publishing
  needs an automated guarantee that no commercial-licensed file is shipped.

### How it differs from catapult
- No from-source build — rest is just Node + `npm install --omit=dev`. `Dockerfile.nemtus`
  mirrors the upstream `client/rest/Dockerfile` and adds labels / the license gate /
  ENTRYPOINT. It is kept SEPARATE from the upstream Dockerfile so mirror-sync keeps it.

## What's included (`client/rest/` + CI)
- **Dockerfile.nemtus** — Ubuntu + Node (NodeSource), `USER 1000`, OCI labels, in-image
  license-scope gate + PASS report at `/app/licenses/`, `ENTRYPOINT ["node"]` /
  `CMD ["src/index.js"]` (override the script arg for the light/rosetta variants).
- **scripts/check-license-scope.sh** — single source-of-truth gate; fails on any Tech
  Bureau Commercial-licensed file. Allowlists the generated Rosetta client
  (`src/plugins/rosetta/openApi/**`, Apache-2.0) and headerless `src/plugins/metadata/metal.js`.
- **scripts/build-docker-rest.sh**, **THIRD_PARTY_NOTICES.md**, **docs/PUBLISHING-COMPLIANCE.md**.
- **.github/workflows/rest-image.yml** — PR builds + smoke-tests (no push); a
  `rest-image-v*` tag publishes to GHCR (public) with SBOM + provenance and records
  evidence. Gate runs before publish. Only the pinned `actions/checkout` + buildx.
- **apply-nemtus-patch.sh** — adds `rest-image.yml` to `nemtus_workflows` (survives sync).

## Notes / follow-ups (not blocking)
- One-time GHCR setup: first publish creates a *private* package; flip it to Public once
  (the **org** must allow public packages too — see #33 thread).
- Recommend keeping `rest-image` out of the `dev` required status checks.
- cosign signing left as a documented TODO (SBOM + provenance cover provenance for now).

## Test plan (done locally)
- `bash client/rest/scripts/check-license-scope.sh` → PASS (0 commercial files; Rosetta
  generated client + metal.js allowlisted). Verified it FAILS on a planted commercial-header file.
- Built the image: OCI labels present, `ENTRYPOINT ["node"] CMD ["src/index.js"]`, USER 1000,
  EXPOSE 3000; `/app/{COPYING.LESSER,LICENSE.txt,THIRD_PARTY_NOTICES.md}` + the gate PASS report
  bundled; 148 production npm packages present; `node --check` passes for index.js / index.light.js
  / index.rosetta.js.
- mirror-ci no-drift: re-running `apply-nemtus-patch.sh` produces no diff; `rest-image.yml` survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new build-and-publish pipeline for the REST image, including pull-request smoke checks and release publishing to container registry.
  * Added a dedicated build process for the REST container image with support for versioned builds and provenance metadata.

* **Documentation**
  * Added publishing-compliance and third-party notices documentation for the REST image, including licensing and source availability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->