### PR TITLE
feat(pypi): mirror symbol-sdk-python + catparser to PyPI

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -8,6 +8,12 @@
 #     so it always matches upstream)
 #   - openapi package name -> @nemtus/symbol-openapi (version left as-is too);
 #     ships only the bundled spec (openapi3.yml/json + postman.json)
+#   - sdk/python PyPI distribution name -> nemtus-symbol-sdk (PyPI has no scopes;
+#     the `-python` suffix is dropped to read alongside @nemtus/symbol-sdk on npm.
+#     The import module name `symbolchain` is left untouched, and the version is
+#     left as-is so it always matches upstream)
+#   - catbuffer/parser PyPI distribution name -> nemtus-catparser (import module
+#     name `catparser` left untouched; version left as-is)
 #   - publishConfig.access=public (scoped packages)
 #   - repository / bugs / homepage point at nemtus/symbol
 #   - a "mirror" notice is prepended to the root README.md
@@ -26,10 +32,12 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 pkg_dir="${repo_root}/sdk/javascript"
 openapi_dir="${repo_root}/openapi"
+py_sdk_dir="${repo_root}/sdk/python"
+py_parser_dir="${repo_root}/catbuffer/parser"
 readme="${repo_root}/README.md"
 
 # nemtus-owned GitHub workflows that must survive the strip below.
-nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml')
+nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml' 'pypi-sdk-publish.yml' 'pypi-catparser-publish.yml')
 
 echo "==> patching ${pkg_dir}/package.json"
 cd "${pkg_dir}"
@@ -140,6 +148,124 @@ EOF
 else
 	echo "    notice already present or no README"
 fi
+
+# --- PyPI mirror layer (sdk/python, catbuffer/parser) ----------------------------
+#
+# PyPI has no scopes, so the distribution name is a flat unique string. We only
+# rewrite the *distribution* name (and repository/description metadata) — the
+# import module name (`symbolchain`, `catparser`) is intentionally left untouched,
+# matching the "change only the published name" mirror principle. pyproject.toml is
+# not npm, so we edit it with anchored sed. The patterns match the EXACT upstream
+# lines, so a second run is a no-op (idempotent -> mirror-ci no-drift stays green).
+py_sdk_toml="${py_sdk_dir}/pyproject.toml"
+echo "==> patching ${py_sdk_toml}"
+# name: symbol-sdk-python -> nemtus-symbol-sdk (drop redundant -python on PyPI)
+sed -i "s|^name = 'symbol-sdk-python'\$|name = 'nemtus-symbol-sdk'|" "${py_sdk_toml}"
+# description: disambiguate from the npm @nemtus/symbol-sdk (same stem, other registry)
+sed -i "s|^description = 'Symbol SDK'\$|description = 'Symbol Python SDK (nemtus mirror of upstream symbol-sdk-python; import module: symbolchain)'|" "${py_sdk_toml}"
+sed -i "s|^repository = 'https://github.com/symbol/symbol/tree/main/sdk/python'\$|repository = 'https://github.com/nemtus/symbol/tree/dev/sdk/python'|" "${py_sdk_toml}"
+
+py_parser_toml="${py_parser_dir}/pyproject.toml"
+echo "==> patching ${py_parser_toml}"
+# name: catparser -> nemtus-catparser. The `packages = [{ include = 'catparser' }]`
+# line does NOT start with `name = `, so the anchored pattern can't touch it.
+sed -i "s|^name = 'catparser'\$|name = 'nemtus-catparser'|" "${py_parser_toml}"
+sed -i "s|^repository = 'https://github.com/symbol/symbol/tree/main/catbuffer/parser'\$|repository = 'https://github.com/nemtus/symbol/tree/dev/catbuffer/parser'|" "${py_parser_toml}"
+
+# sdk/python ships NO LICENSE upstream (catbuffer/parser already ships an MIT one,
+# which we leave untouched). Mirror the sdk/javascript approach: create an MIT
+# LICENSE with a truthful provenance note and a no-copyright disclaimer, only when
+# absent — never clobber a license upstream might add later. Poetry includes a
+# top-level LICENSE in the sdist/wheel automatically.
+py_sdk_license="${py_sdk_dir}/LICENSE"
+echo "==> ensuring MIT LICENSE in ${py_sdk_license}"
+if [ ! -e "${py_sdk_license}" ]; then
+	cat > "${py_sdk_license}" <<'EOF'
+MIT License
+
+This package is a redistribution of `symbol-sdk-python` (import module
+`symbolchain`) from the upstream project symbol/symbol
+(https://github.com/symbol/symbol), published by its authors — identified in the
+upstream package metadata as "Symbol Contributors <contributors@symbol.dev>" —
+under the MIT License. The nemtus mirror asserts no copyright over this software
+and changes nothing but the published PyPI distribution name (to
+`nemtus-symbol-sdk`). The authoritative copyright and license are upstream's.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+EOF
+	echo "    LICENSE created"
+else
+	echo "    LICENSE already present (left as-is)"
+fi
+
+# The root README notice does not travel inside the PyPI sdist (PyPI ships each
+# package's own README), so prepend an equivalent notice to each package README.
+# The sdk/python notice also states the distribution-name change explicitly, so a
+# reader can't confuse `nemtus-symbol-sdk` (PyPI, Python) with @nemtus/symbol-sdk
+# (npm, JavaScript).
+py_sdk_readme="${py_sdk_dir}/README.md"
+echo "==> ensuring mirror notice in ${py_sdk_readme}"
+if [ -f "${py_sdk_readme}" ] && ! grep -qF '<!-- nemtus-mirror-notice -->' "${py_sdk_readme}"; then
+	tmp="$(mktemp)"
+	cat > "${tmp}" <<'EOF'
+<!-- nemtus-mirror-notice -->
+> **Note (nemtus mirror):** This package is a content mirror of the **Python** SDK
+> from [`symbol/symbol`](https://github.com/symbol/symbol) (`sdk/python`, upstream
+> PyPI name `symbol-sdk-python`). nemtus republishes it on PyPI as
+> [`nemtus-symbol-sdk`](https://pypi.org/project/nemtus-symbol-sdk/); the only
+> change from upstream is the published distribution name. The import module name
+> is unchanged — you still `import symbolchain`. This is distinct from
+> `@nemtus/symbol-sdk` on npm, which mirrors the JavaScript SDK. For the canonical
+> project, see [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
+EOF
+	cat "${py_sdk_readme}" >> "${tmp}"
+	mv "${tmp}" "${py_sdk_readme}"
+	echo "    notice inserted"
+else
+	echo "    notice already present or no README"
+fi
+
+py_parser_readme="${py_parser_dir}/README.md"
+echo "==> ensuring mirror notice in ${py_parser_readme}"
+if [ -f "${py_parser_readme}" ] && ! grep -qF '<!-- nemtus-mirror-notice -->' "${py_parser_readme}"; then
+	tmp="$(mktemp)"
+	cat > "${tmp}" <<'EOF'
+<!-- nemtus-mirror-notice -->
+> **Note (nemtus mirror):** This package is a content mirror of the catbuffer
+> parser from [`symbol/symbol`](https://github.com/symbol/symbol)
+> (`catbuffer/parser`, upstream PyPI name `catparser`). nemtus republishes it on
+> PyPI as [`nemtus-catparser`](https://pypi.org/project/nemtus-catparser/); the
+> only change from upstream is the published distribution name. The import module
+> name is unchanged — you still `import catparser`. For the canonical project, see
+> [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
+EOF
+	cat "${py_parser_readme}" >> "${tmp}"
+	mv "${tmp}" "${py_parser_readme}"
+	echo "    notice inserted"
+else
+	echo "    notice already present or no README"
+fi
+# --- end PyPI mirror layer -------------------------------------------------------
 
 echo "==> ensuring mirror notice in ${readme}"
 notice_marker='<!-- nemtus-mirror-notice -->'

--- a/.github/workflows/pypi-catparser-publish.yml
+++ b/.github/workflows/pypi-catparser-publish.yml
@@ -1,0 +1,170 @@
+name: publish nemtus-catparser (PyPI)
+
+# Single, trusted publish path for the scoped mirror of the catbuffer parser.
+# Publishing uses PyPI Trusted Publishing (OIDC) — NO long-lived PyPI token.
+# The `pypi-production` environment carries a required-reviewers protection rule,
+# so every publish pauses for manual approval.
+#
+# Mirror identity:
+#   upstream PyPI dist:  catparser          (import module: catparser)
+#   nemtus PyPI dist:    nemtus-catparser   (import module unchanged: catparser)
+# Only the published distribution name changes; the version tracks upstream.
+#
+# Triggers:
+#   - push to dev touching catbuffer/parser/pyproject.toml (i.e. a merged
+#     mirror-sync PR that bumped the upstream version) -> auto-publish, gated by approval
+#   - manual workflow_dispatch
+#
+# PyPI Trusted Publisher config must match:
+#   repository:  nemtus/symbol
+#   workflow:    pypi-catparser-publish.yml
+#   environment: pypi-production
+# For the very first release, register this as a PyPI "pending publisher" (the
+# project does not exist yet); the first successful run creates the project.
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'catbuffer/parser/pyproject.toml'
+  workflow_dispatch:
+
+# Minimal default for every job; the publish job re-grants id-token: write below
+# for PyPI Trusted Publishing (OIDC).
+permissions:
+  contents: read
+
+env:
+  PYPI_NAME: nemtus-catparser
+  PKG_DIR: catbuffer/parser
+
+jobs:
+  # Decide whether the version on dev differs from what is already on PyPI.
+  # Kept separate so the pypi-production approval prompt only appears when we
+  # actually intend to publish.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          # This workflow never pushes to git (publishing is via OIDC), so don't
+          # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
+          persist-credentials: false
+
+      # Pin the runtime so the gate doesn't depend on the runner's preinstalled
+      # Python. tomllib is stdlib on 3.11+.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Compare dev version with PyPI
+        id: decide
+        run: |
+          version="$(python -c "import tomllib;print(tomllib.load(open('${PKG_DIR}/pyproject.toml','rb'))['tool']['poetry']['version'])")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          # Query the PyPI JSON API for the current latest version.
+          #   200 -> compare versions
+          #   404 -> project does not exist yet (first/bootstrap publish)
+          #   anything else -> fail closed (transient registry/network error); guessing
+          #     would either skip a real publish or trigger a doomed one + needless approval.
+          code="$(curl -sS -o /tmp/pypi.json -w '%{http_code}' "https://pypi.org/pypi/${PYPI_NAME}/json" || echo 000)"
+          if [ "${code}" = "404" ]; then
+            echo "PyPI has no ${PYPI_NAME} yet: bootstrap publish of ${version}."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          elif [ "${code}" = "200" ]; then
+            pypi_version="$(python -c "import json;print(json.load(open('/tmp/pypi.json'))['info']['version'])")"
+            if [ "${version}" != "${pypi_version}" ]; then
+              echo "PyPI ${pypi_version} -> ${version}: will publish."
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "PyPI already at ${pypi_version}: nothing to publish."
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::error::unexpected HTTP ${code} from PyPI for ${PYPI_NAME}; aborting to avoid a false publish." >&2
+            exit 1
+          fi
+
+  publish:
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi-production
+    permissions:
+      id-token: write   # required for PyPI Trusted Publishing (OIDC)
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      # The rename layer also rewrites sdk/javascript/package.json via `npm pkg set`,
+      # so Node must be present for the idempotent safety net to run (matches publish.yml).
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      # Idempotent safety net: ensures the nemtus-catparser distribution name is set
+      # even on a manual dispatch from a not-yet-patched tree.
+      - name: Apply nemtus rename layer
+        run: bash .github/scripts/apply-nemtus-patch.sh
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      # NOTE: unlike the SDK, we do NOT inject requirements.txt here. Upstream's
+      # published `catparser` declares NO runtime dependencies (PyPI requires_dist is
+      # null), even though its requirements.txt lists lark/PyYAML. A faithful mirror
+      # matches upstream exactly, so a plain `poetry build` (deps: python only) is
+      # correct — it reproduces upstream's empty Requires-Dist.
+      - name: Build sdist + wheel
+        working-directory: ${{ env.PKG_DIR }}
+        run: poetry build
+
+      - name: Publish to PyPI (OIDC, attestations)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: ${{ env.PKG_DIR }}/dist
+
+  # Record-keeping tag + GitHub Release for the version just published.
+  #
+  # SECURITY: contents: write is isolated to THIS job, which runs NO build and NO
+  # third-party code — only the `gh` CLI against the GitHub API. The build/publish
+  # job above stays at contents: read, so a supply-chain compromise in `poetry build`
+  # can never reach this write token. There is no checkout step (gh needs none), so
+  # nothing from the repo tree executes here either.
+  tag:
+    needs: [check, publish]   # runs only if publish succeeded
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          tag="${PYPI_NAME}@${VERSION}"
+          # Idempotent: a re-run (or a manual dispatch after a tag already exists)
+          # must not fail.
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "release ${tag} already exists; nothing to do."
+            exit 0
+          fi
+          # Tag the exact commit this run published from (the dev commit carrying the
+          # published pyproject for a push; the dispatched dev tip otherwise).
+          gh release create "${tag}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "${PYPI_NAME} v${VERSION}" \
+            --notes "Mirror of upstream symbol/symbol. Published \`${PYPI_NAME}\` ${VERSION} to PyPI (import module: catparser)."

--- a/.github/workflows/pypi-catparser-publish.yml
+++ b/.github/workflows/pypi-catparser-publish.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          ref: ${{ github.sha }}
           # This workflow never pushes to git (publishing is via OIDC), so don't
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
@@ -78,11 +78,16 @@ jobs:
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           elif [ "${code}" = "200" ]; then
             pypi_version="$(python -c "import json;print(json.load(open('/tmp/pypi.json'))['info']['version'])")"
-            if [ "${version}" != "${pypi_version}" ]; then
-              echo "PyPI ${pypi_version} -> ${version}: will publish."
+            # Publish only on a FORWARD version move. `sort -V` puts the higher
+            # version last; require that to equal ours. This blocks a downgrade /
+            # backfill (dev reverted, or an older run approved after a newer release
+            # already exists) from trying to publish an old version over a newer one.
+            newest="$(printf '%s\n%s\n' "${version}" "${pypi_version}" | sort -V | tail -n1)"
+            if [ "${version}" != "${pypi_version}" ] && [ "${newest}" = "${version}" ]; then
+              echo "PyPI ${pypi_version} -> ${version}: forward move, will publish."
               echo "should_publish=true" >> "$GITHUB_OUTPUT"
             else
-              echo "PyPI already at ${pypi_version}: nothing to publish."
+              echo "PyPI at ${pypi_version}, dev at ${version}: not a forward move, nothing to publish."
               echo "should_publish=false" >> "$GITHUB_OUTPUT"
             fi
           else
@@ -101,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/pypi-sdk-publish.yml
+++ b/.github/workflows/pypi-sdk-publish.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          ref: ${{ github.sha }}
           # This workflow never pushes to git (publishing is via OIDC), so don't
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
@@ -78,11 +78,16 @@ jobs:
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           elif [ "${code}" = "200" ]; then
             pypi_version="$(python -c "import json;print(json.load(open('/tmp/pypi.json'))['info']['version'])")"
-            if [ "${version}" != "${pypi_version}" ]; then
-              echo "PyPI ${pypi_version} -> ${version}: will publish."
+            # Publish only on a FORWARD version move. `sort -V` puts the higher
+            # version last; require that to equal ours. This blocks a downgrade /
+            # backfill (dev reverted, or an older run approved after a newer release
+            # already exists) from trying to publish an old version over a newer one.
+            newest="$(printf '%s\n%s\n' "${version}" "${pypi_version}" | sort -V | tail -n1)"
+            if [ "${version}" != "${pypi_version}" ] && [ "${newest}" = "${version}" ]; then
+              echo "PyPI ${pypi_version} -> ${version}: forward move, will publish."
               echo "should_publish=true" >> "$GITHUB_OUTPUT"
             else
-              echo "PyPI already at ${pypi_version}: nothing to publish."
+              echo "PyPI at ${pypi_version}, dev at ${version}: not a forward move, nothing to publish."
               echo "should_publish=false" >> "$GITHUB_OUTPUT"
             fi
           else
@@ -101,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/pypi-sdk-publish.yml
+++ b/.github/workflows/pypi-sdk-publish.yml
@@ -1,0 +1,183 @@
+name: publish nemtus-symbol-sdk (PyPI)
+
+# Single, trusted publish path for the scoped mirror of the Python SDK.
+# Publishing uses PyPI Trusted Publishing (OIDC) — NO long-lived PyPI token.
+# The `pypi-production` environment carries a required-reviewers protection rule,
+# so every publish pauses for manual approval.
+#
+# Mirror identity:
+#   upstream PyPI dist:  symbol-sdk-python   (import module: symbolchain)
+#   nemtus PyPI dist:    nemtus-symbol-sdk   (import module unchanged: symbolchain)
+# Only the published distribution name changes; the version tracks upstream.
+#
+# Triggers:
+#   - push to dev touching sdk/python/pyproject.toml (i.e. a merged mirror-sync
+#     PR that bumped the upstream version) -> auto-publish, gated by approval
+#   - manual workflow_dispatch
+#
+# PyPI Trusted Publisher config must match:
+#   repository:  nemtus/symbol
+#   workflow:    pypi-sdk-publish.yml
+#   environment: pypi-production
+# For the very first release, register this as a PyPI "pending publisher" (the
+# project does not exist yet); the first successful run creates the project.
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'sdk/python/pyproject.toml'
+  workflow_dispatch:
+
+# Minimal default for every job; the publish job re-grants id-token: write below
+# for PyPI Trusted Publishing (OIDC).
+permissions:
+  contents: read
+
+env:
+  PYPI_NAME: nemtus-symbol-sdk
+  PKG_DIR: sdk/python
+
+jobs:
+  # Decide whether the version on dev differs from what is already on PyPI.
+  # Kept separate so the pypi-production approval prompt only appears when we
+  # actually intend to publish.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          # This workflow never pushes to git (publishing is via OIDC), so don't
+          # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
+          persist-credentials: false
+
+      # Pin the runtime so the gate doesn't depend on the runner's preinstalled
+      # Python. tomllib is stdlib on 3.11+.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Compare dev version with PyPI
+        id: decide
+        run: |
+          version="$(python -c "import tomllib;print(tomllib.load(open('${PKG_DIR}/pyproject.toml','rb'))['tool']['poetry']['version'])")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          # Query the PyPI JSON API for the current latest version.
+          #   200 -> compare versions
+          #   404 -> project does not exist yet (first/bootstrap publish)
+          #   anything else -> fail closed (transient registry/network error); guessing
+          #     would either skip a real publish or trigger a doomed one + needless approval.
+          code="$(curl -sS -o /tmp/pypi.json -w '%{http_code}' "https://pypi.org/pypi/${PYPI_NAME}/json" || echo 000)"
+          if [ "${code}" = "404" ]; then
+            echo "PyPI has no ${PYPI_NAME} yet: bootstrap publish of ${version}."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          elif [ "${code}" = "200" ]; then
+            pypi_version="$(python -c "import json;print(json.load(open('/tmp/pypi.json'))['info']['version'])")"
+            if [ "${version}" != "${pypi_version}" ]; then
+              echo "PyPI ${pypi_version} -> ${version}: will publish."
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "PyPI already at ${pypi_version}: nothing to publish."
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::error::unexpected HTTP ${code} from PyPI for ${PYPI_NAME}; aborting to avoid a false publish." >&2
+            exit 1
+          fi
+
+  publish:
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi-production
+    permissions:
+      id-token: write   # required for PyPI Trusted Publishing (OIDC)
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      # The rename layer also rewrites sdk/javascript/package.json via `npm pkg set`,
+      # so Node must be present for the idempotent safety net to run (matches publish.yml).
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      # Idempotent safety net: ensures the nemtus-symbol-sdk distribution name is set
+      # even on a manual dispatch from a not-yet-patched tree.
+      - name: Apply nemtus rename layer
+        run: bash .github/scripts/apply-nemtus-patch.sh
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      # Faithful-mirror dependency injection.
+      # Upstream symbol-sdk-python keeps its runtime deps in requirements.txt (NOT in
+      # [tool.poetry.dependencies], which only declares python), and upstream's publish
+      # pipeline injects them — its published wheel declares all 9 as Requires-Dist
+      # (e.g. cryptography>=49.0.0,<49.1.0). We reproduce that so `pip install
+      # nemtus-symbol-sdk` pulls the same deps; without this the mirror would install
+      # but fail at `import symbolchain` (missing cryptography et al.). `poetry add`
+      # uses poetry-core's own PEP 440 parser, so requirements.txt `~=` specifiers map
+      # to the exact same ranges upstream publishes — no hand-rolled translation. This
+      # edits the runner's working tree only (never committed), exactly like upstream's
+      # ephemeral build-time injection.
+      - name: Inject runtime dependencies from requirements.txt
+        working-directory: ${{ env.PKG_DIR }}
+        run: |
+          mapfile -t reqs < <(grep -vE '^[[:space:]]*(#|$)' requirements.txt)
+          echo "Injecting ${#reqs[@]} runtime deps: ${reqs[*]}"
+          poetry add --lock "${reqs[@]}"
+
+      - name: Build sdist + wheel
+        working-directory: ${{ env.PKG_DIR }}
+        run: poetry build
+
+      - name: Publish to PyPI (OIDC, attestations)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: ${{ env.PKG_DIR }}/dist
+
+  # Record-keeping tag + GitHub Release for the version just published.
+  #
+  # SECURITY: contents: write is isolated to THIS job, which runs NO build and NO
+  # third-party code — only the `gh` CLI against the GitHub API. The build/publish
+  # job above stays at contents: read, so a supply-chain compromise in `poetry build`
+  # can never reach this write token. There is no checkout step (gh needs none), so
+  # nothing from the repo tree executes here either.
+  tag:
+    needs: [check, publish]   # runs only if publish succeeded
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          tag="${PYPI_NAME}@${VERSION}"
+          # Idempotent: a re-run (or a manual dispatch after a tag already exists)
+          # must not fail.
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "release ${tag} already exists; nothing to do."
+            exit 0
+          fi
+          # Tag the exact commit this run published from (the dev commit carrying the
+          # published pyproject for a push; the dispatched dev tip otherwise).
+          gh release create "${tag}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "${PYPI_NAME} v${VERSION}" \
+            --notes "Mirror of upstream symbol/symbol. Published \`${PYPI_NAME}\` ${VERSION} to PyPI (import module: symbolchain)."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,16 @@ conventions for **manually creating tags and GitHub Releases**.
 | --- | --- | --- | --- |
 | `sdk/javascript` | `@nemtus/symbol-sdk` | MIT | npm |
 | `openapi` | `@nemtus/symbol-openapi` | Apache-2.0 | npm |
+| `sdk/python` | `nemtus-symbol-sdk` (import module `symbolchain`) | MIT | PyPI |
+| `catbuffer/parser` | `nemtus-catparser` (import module `catparser`) | MIT | PyPI |
 | `client/rest` | `symbol-api-rest` | LGPL family | **Not published** (no tag) |
+
+> PyPI has no scopes, so the distribution names are flat. Upstream is
+> `symbol-sdk-python` / `catparser`; nemtus republishes them as `nemtus-symbol-sdk`
+> / `nemtus-catparser`. Only the **distribution** name changes — the import module
+> name (`symbolchain` / `catparser`) is unchanged. The SDK drops the redundant
+> `-python` suffix so it reads alongside `@nemtus/symbol-sdk` on npm; the two are
+> different artifacts on different registries (PyPI/Python vs npm/JavaScript).
 
 ## Principles
 
@@ -22,9 +31,26 @@ conventions for **manually creating tags and GitHub Releases**.
   what is already on npm whenever `dev` is pushed (*version-diff driven*):
   - `.github/workflows/publish.yml` — `@nemtus/symbol-sdk`
   - `.github/workflows/openapi-publish.yml` — `@nemtus/symbol-openapi`
+  - `.github/workflows/pypi-sdk-publish.yml` — `nemtus-symbol-sdk` (PyPI)
+  - `.github/workflows/pypi-catparser-publish.yml` — `nemtus-catparser` (PyPI)
 
-  Both publish through the `npm-production` environment, which requires reviewer
-  approval.
+  The npm workflows publish through the `npm-production` environment; the PyPI
+  workflows publish through `pypi-production`. Both environments require reviewer
+  approval. npm uses npm Trusted Publishing (OIDC); PyPI uses PyPI Trusted
+  Publishing (OIDC). Neither uses a long-lived token.
+
+  > First-time PyPI setup (one-off, manual): register each package as a PyPI
+  > **pending publisher** (repository `nemtus/symbol`, the workflow filename above,
+  > environment `pypi-production`) before the first run, and create the
+  > `pypi-production` GitHub environment with required reviewers.
+
+  **Tagging differs by ecosystem.** The npm workflows do NOT tag (see the manual
+  procedure below). The **PyPI workflows tag automatically**: after a successful
+  publish, a separate `tag` job creates `nemtus-symbol-sdk@<version>` /
+  `nemtus-catparser@<version>` and a matching GitHub Release. That job is the only
+  place `contents: write` is granted, and it runs **no build and no third-party
+  code** (just the `gh` CLI), so the `contents: read` build/publish job is never
+  exposed to a write token. The job is idempotent (skips if the release exists).
 - Therefore **tags / Releases are not the publish trigger; they are record-keeping
   markers** that pin "which commit corresponds to which version of which artifact."
 
@@ -41,7 +67,13 @@ Examples:
 ```text
 @nemtus/symbol-sdk@3.3.2       → @nemtus/symbol-sdk@3.3.2 on npm
 @nemtus/symbol-openapi@1.0.6   → @nemtus/symbol-openapi@1.0.6 on npm
+nemtus-symbol-sdk@3.3.2        → nemtus-symbol-sdk 3.3.2 on PyPI
+nemtus-catparser@3.2.0         → nemtus-catparser 3.2.0 on PyPI
 ```
+
+(PyPI distribution names have no `@scope`, so the tag is just
+`<dist-name>@<version>`. It still lives in a namespace upstream never uses, so it
+cannot collide with upstream's `sdk/python/v*` / `catbuffer/parser/v*` tags.)
 
 - **Do NOT use a `<package path>/v<semver>` scheme** (e.g. `sdk/javascript/v3.3.2`,
   `openapi/v1.0.6`). This repository is a mirror, so it inherits upstream

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,11 +24,14 @@ conventions for **manually creating tags and GitHub Releases**.
 ## Principles
 
 - **Each artifact is versioned independently with semver.** A bump in the SDK
-  does not require bumping openapi. The `version` field in each `package.json`
-  is the source of truth for that package.
-- **Tags do NOT trigger npm publishing.** Publishing is driven by the following
-  workflows, which compare the `version` in the relevant `package.json` against
-  what is already on npm whenever `dev` is pushed (*version-diff driven*):
+  does not require bumping openapi. The `version` field in each package manifest
+  is the source of truth for that package — `package.json` for the npm packages
+  (`sdk/javascript`, `openapi`), `pyproject.toml` for the PyPI packages
+  (`sdk/python`, `catbuffer/parser`).
+- **Tags do NOT trigger publishing.** Publishing is driven by the following
+  workflows, which compare the `version` in the relevant manifest against what is
+  already on the registry (npm or PyPI) whenever `dev` is pushed (*version-diff
+  driven*):
   - `.github/workflows/publish.yml` — `@nemtus/symbol-sdk`
   - `.github/workflows/openapi-publish.yml` — `@nemtus/symbol-openapi`
   - `.github/workflows/pypi-sdk-publish.yml` — `nemtus-symbol-sdk` (PyPI)
@@ -56,10 +59,12 @@ conventions for **manually creating tags and GitHub Releases**.
 
 ## Tag naming convention
 
-Use the **published npm coordinate** as the tag name:
+Use the **published package coordinate** as the tag name — the npm package name
+for npm artifacts, the PyPI distribution name for PyPI artifacts:
 
 ```text
-@nemtus/<package>@<version>
+@nemtus/<package>@<version>   # npm artifacts
+<dist-name>@<version>         # PyPI artifacts
 ```
 
 Examples:

--- a/catbuffer/parser/README.md
+++ b/catbuffer/parser/README.md
@@ -1,3 +1,13 @@
+<!-- nemtus-mirror-notice -->
+> **Note (nemtus mirror):** This package is a content mirror of the catbuffer
+> parser from [`symbol/symbol`](https://github.com/symbol/symbol)
+> (`catbuffer/parser`, upstream PyPI name `catparser`). nemtus republishes it on
+> PyPI as [`nemtus-catparser`](https://pypi.org/project/nemtus-catparser/); the
+> only change from upstream is the published distribution name. The import module
+> name is unchanged — you still `import catparser`. For the canonical project, see
+> [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
 # catbuffer-parser
 
 [![Build Status](https://api.travis-ci.com/symbol/catbuffer-parser.svg?branch=main)](https://travis-ci.com/symbol/catbuffer-parser)

--- a/catbuffer/parser/pyproject.toml
+++ b/catbuffer/parser/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = 'catparser'
+name = 'nemtus-catparser'
 version = '3.2.0'
 description = 'Symbol Catbuffer Parser'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
@@ -10,7 +10,7 @@ readme = 'README.md'
 
 packages = [{ include = 'catparser' }]
 
-repository = 'https://github.com/symbol/symbol/tree/main/catbuffer/parser'
+repository = 'https://github.com/nemtus/symbol/tree/dev/catbuffer/parser'
 
 keywords = ['symbol', 'catbuffer', 'catparser', 'parser', 'catbuffer-parser']
 

--- a/sdk/python/LICENSE
+++ b/sdk/python/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+This package is a redistribution of `symbol-sdk-python` (import module
+`symbolchain`) from the upstream project symbol/symbol
+(https://github.com/symbol/symbol), published by its authors — identified in the
+upstream package metadata as "Symbol Contributors <contributors@symbol.dev>" —
+under the MIT License. The nemtus mirror asserts no copyright over this software
+and changes nothing but the published PyPI distribution name (to
+`nemtus-symbol-sdk`). The authoritative copyright and license are upstream's.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,3 +1,14 @@
+<!-- nemtus-mirror-notice -->
+> **Note (nemtus mirror):** This package is a content mirror of the **Python** SDK
+> from [`symbol/symbol`](https://github.com/symbol/symbol) (`sdk/python`, upstream
+> PyPI name `symbol-sdk-python`). nemtus republishes it on PyPI as
+> [`nemtus-symbol-sdk`](https://pypi.org/project/nemtus-symbol-sdk/); the only
+> change from upstream is the published distribution name. The import module name
+> is unchanged — you still `import symbolchain`. This is distinct from
+> `@nemtus/symbol-sdk` on npm, which mirrors the JavaScript SDK. For the canonical
+> project, see [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
 # Symbol-SDK
 
 [![lint][sdk-python-lint]][sdk-python-job] [![test][sdk-python-test]][sdk-python-job] [![vectors][sdk-python-vectors]][sdk-python-job] [![][sdk-python-cov]][sdk-python-cov-link] [![][sdk-python-package]][sdk-python-package-link]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = 'symbol-sdk-python'
+name = 'nemtus-symbol-sdk'
 version = '3.3.2'
-description = 'Symbol SDK'
+description = 'Symbol Python SDK (nemtus mirror of upstream symbol-sdk-python; import module: symbolchain)'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['Symbol Contributors <contributors@symbol.dev>']
 license = 'MIT'
@@ -10,7 +10,7 @@ readme = 'README.md'
 
 packages = [{ include = 'symbolchain' }]
 
-repository = 'https://github.com/symbol/symbol/tree/main/sdk/python'
+repository = 'https://github.com/nemtus/symbol/tree/dev/sdk/python'
 
 keywords = ['symbol', 'sdk', 'Symbol SDK']
 


### PR DESCRIPTION
## Summary

Mirror the two upstream **PyPI** packages from the `symbol/symbol` monorepo under nemtus-owned distribution names, completing SDK/parser parity with the existing npm mirrors (`@nemtus/symbol-sdk`, `@nemtus/symbol-openapi`).

| upstream (PyPI) | nemtus (PyPI) | import module (unchanged) | License |
| --- | --- | --- | --- |
| `symbol-sdk-python` | `nemtus-symbol-sdk` | `symbolchain` | MIT |
| `catparser` | `nemtus-catparser` | `catparser` | MIT |

PyPI has no scopes, so names are flat. The SDK drops the redundant `-python` suffix to read alongside `@nemtus/symbol-sdk` on npm; the README/description disambiguate it from the npm (JavaScript) artifact.

## What's included

**Rename layer** (`.github/scripts/apply-nemtus-patch.sh`)
- Idempotent anchored-`sed` rewrite of pyproject `name`/`repository`/`description` (matches exact upstream lines → re-runs are no-ops → `mirror-ci` no-drift stays green after a `git merge -X theirs` sync).
- Creates an MIT `LICENSE` with a provenance/no-copyright disclaimer for `sdk/python` (absent upstream); leaves `catbuffer/parser`'s existing LICENSE untouched.
- Prepends a mirror notice to each package README (travels inside the sdist).
- Adds the two new workflows to the `nemtus_workflows` allow-list.

**Publish workflows** — `pypi-sdk-publish.yml`, `pypi-catparser-publish.yml` (version-diff driven, matching the npm SDK model)
- `check` compares the pyproject version against the PyPI JSON API (`404` → bootstrap publish; non-`200`/`404` → fail closed).
- `publish` uses **PyPI Trusted Publishing (OIDC, no token)**, gated by the `pypi-production` environment approval; all actions SHA-pinned.
- **Faithful dependency injection:** upstream `symbol-sdk-python` declares its 9 runtime deps (kept in `requirements.txt`) as `Requires-Dist`, so the SDK job runs `poetry add --lock` before build to reproduce them; `catparser` declares none upstream (`requires_dist` null), so it builds as-is.

**Automated tagging (isolated, least-privilege)**
- A separate `tag` job creates `nemtus-symbol-sdk@<ver>` / `nemtus-catparser@<ver>` + a GitHub Release after a successful publish.
- `contents: write` is confined to this job, which runs **no build and no third-party code** (`gh` CLI only); the build/publish job stays `contents: read`, so a supply-chain compromise can't reach the write token. Idempotent (skips if the release exists).

## Verification done locally
- `apply-nemtus-patch.sh` **idempotency** (2× run → no further changes; no duplicate notices; no double prefix).
- Both workflow YAMLs parse; every `uses:` is SHA-pinned (`setup-python@ece7cb06` v6.3.0, `gh-action-pypi-publish@cef22109` v1.14.0).
- `check` version read (tomllib) and PyPI `404`/`200` decision confirmed against the live API (`nemtus-symbol-sdk` → 404 = bootstrap).
- Allow-list covers all 9 committed workflows (no-drift safe).

> `poetry build` and the post-build `Requires-Dist` are validated in CI (no local poetry/node).

## One-off manual setup (already done by maintainer)
1. PyPI **pending Trusted Publisher** for each package (repo `nemtus/symbol`, the workflow filename, environment `pypi-production`).
2. GitHub **`pypi-production` environment** with required reviewers.

> ⚠️ Merge note: this branch is a normal feature PR (not a mirror-sync PR), so squash/merge is fine here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PyPI publishing for mirrored Python packages, including version checks, release tagging, and approval-gated publishing.
  * Updated package metadata and publishing names for the Python SDK and parser packages.
* **Documentation**
  * Added mirror notices to the Python package READMEs and updated release notes to explain PyPI naming and tagging.
* **Bug Fixes**
  * Ensured required license files and mirror notices are present for Python packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->