### PR TITLE
fix(pypi): NEMTUS maintainer + one-time .post1 release to ship it

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -151,12 +151,16 @@ fi
 
 # --- PyPI mirror layer (sdk/python, catbuffer/parser) ----------------------------
 #
-# PyPI has no scopes, so the distribution name is a flat unique string. We only
-# rewrite the *distribution* name (and repository/description metadata) — the
-# import module name (`symbolchain`, `catparser`) is intentionally left untouched,
-# matching the "change only the published name" mirror principle. pyproject.toml is
-# not npm, so we edit it with anchored sed. The patterns match the EXACT upstream
-# lines, so a second run is a no-op (idempotent -> mirror-ci no-drift stays green).
+# PyPI has no scopes, so the distribution name is a flat unique string. We
+# rewrite the *distribution* name (and repository/description metadata), and point
+# `maintainers` at NEMTUS (support@nemtus.com) since NEMTUS maintains the
+# republished distribution. `authors` is deliberately LEFT as upstream ("Symbol
+# Contributors") — they wrote the code; changing it would misstate authorship and
+# contradict the LICENSE provenance note. The import module name (`symbolchain`,
+# `catparser`) is also left untouched, matching the "change only the published
+# name / packaging contact" mirror principle. pyproject.toml is not npm, so we edit
+# it with anchored sed. The patterns match the EXACT upstream lines, so a second
+# run is a no-op (idempotent -> mirror-ci no-drift stays green).
 py_sdk_toml="${py_sdk_dir}/pyproject.toml"
 echo "==> patching ${py_sdk_toml}"
 # name: symbol-sdk-python -> nemtus-symbol-sdk (drop redundant -python on PyPI)
@@ -164,6 +168,9 @@ sed -i "s|^name = 'symbol-sdk-python'\$|name = 'nemtus-symbol-sdk'|" "${py_sdk_t
 # description: disambiguate from the npm @nemtus/symbol-sdk (same stem, other registry)
 sed -i "s|^description = 'Symbol SDK'\$|description = 'Symbol Python SDK (nemtus mirror of upstream symbol-sdk-python; import module: symbolchain)'|" "${py_sdk_toml}"
 sed -i "s|^repository = 'https://github.com/symbol/symbol/tree/main/sdk/python'\$|repository = 'https://github.com/nemtus/symbol/tree/dev/sdk/python'|" "${py_sdk_toml}"
+# maintainers -> NEMTUS (packaging contact for the republished dist). `^authors =`
+# is a different line, so this anchored pattern leaves authorship untouched.
+sed -i "s|^maintainers = \['Symbol Contributors <contributors@symbol.dev>'\]\$|maintainers = ['NEMTUS Technical Support <support@nemtus.com>']|" "${py_sdk_toml}"
 
 py_parser_toml="${py_parser_dir}/pyproject.toml"
 echo "==> patching ${py_parser_toml}"
@@ -171,6 +178,8 @@ echo "==> patching ${py_parser_toml}"
 # line does NOT start with `name = `, so the anchored pattern can't touch it.
 sed -i "s|^name = 'catparser'\$|name = 'nemtus-catparser'|" "${py_parser_toml}"
 sed -i "s|^repository = 'https://github.com/symbol/symbol/tree/main/catbuffer/parser'\$|repository = 'https://github.com/nemtus/symbol/tree/dev/catbuffer/parser'|" "${py_parser_toml}"
+# maintainers -> NEMTUS (packaging contact); authors left as upstream.
+sed -i "s|^maintainers = \['Symbol Contributors <contributors@symbol.dev>'\]\$|maintainers = ['NEMTUS Technical Support <support@nemtus.com>']|" "${py_parser_toml}"
 
 # sdk/python ships NO LICENSE upstream (catbuffer/parser already ships an MIT one,
 # which we leave untouched). Mirror the sdk/javascript approach: create an MIT

--- a/catbuffer/parser/pyproject.toml
+++ b/catbuffer/parser/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'nemtus-catparser'
-version = '3.2.0'
+version = '3.2.0.post1'
 description = 'Symbol Catbuffer Parser'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['NEMTUS Technical Support <support@nemtus.com>']

--- a/catbuffer/parser/pyproject.toml
+++ b/catbuffer/parser/pyproject.toml
@@ -3,7 +3,7 @@ name = 'nemtus-catparser'
 version = '3.2.0'
 description = 'Symbol Catbuffer Parser'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
-maintainers = ['Symbol Contributors <contributors@symbol.dev>']
+maintainers = ['NEMTUS Technical Support <support@nemtus.com>']
 license = 'MIT'
 
 readme = 'README.md'

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'nemtus-symbol-sdk'
-version = '3.3.2'
+version = '3.3.2.post1'
 description = 'Symbol Python SDK (nemtus mirror of upstream symbol-sdk-python; import module: symbolchain)'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['NEMTUS Technical Support <support@nemtus.com>']

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -3,7 +3,7 @@ name = 'nemtus-symbol-sdk'
 version = '3.3.2'
 description = 'Symbol Python SDK (nemtus mirror of upstream symbol-sdk-python; import module: symbolchain)'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
-maintainers = ['Symbol Contributors <contributors@symbol.dev>']
+maintainers = ['NEMTUS Technical Support <support@nemtus.com>']
 license = 'MIT'
 
 readme = 'README.md'


### PR DESCRIPTION
## Summary

The PyPI mirrors inherited upstream's packaging contact
(`Symbol Contributors <contributors@symbol.dev>`) in `maintainers`. This sets
**`maintainers = 'NEMTUS Technical Support <support@nemtus.com>'`** for both
`nemtus-symbol-sdk` (`sdk/python`) and `nemtus-catparser` (`catbuffer/parser`),
applied via an idempotent anchored `sed` in the rename layer so it survives every
mirror-sync. `authors` is intentionally **left as upstream** — they wrote the code;
changing it would misstate authorship and contradict the `LICENSE` provenance note.

## One-time `.post1` release (to ship it now)

PyPI is immutable, so the already-published `3.3.2` / `3.2.0` cannot be re-uploaded
with the corrected maintainer. As a deliberate **one-time exception** to "version
tracks upstream exactly", the committed versions are bumped to a PEP 440 post-release
so the publish workflows fire:

| package | version |
| --- | --- |
| `nemtus-symbol-sdk` | `3.3.2` → `3.3.2.post1` |
| `nemtus-catparser` | `3.2.0` → `3.2.0.post1` |

Self-healing: the next mirror-sync restores upstream's version via `git merge -X theirs`
(the rename layer never touches `version`), and the **forward-only** publish check then
prevents a downgrade re-publish of the base over the post-release.

## Why CI stays green
- `verify-rename-layer`: the rename layer doesn't touch `version`/`authors`, and
  `name`/`maintainers` are already nemtus, so re-applying the patch yields no drift.
- `sort -V` (the workflows' forward-only basis) orders `3.3.2.post1` after `3.3.2`,
  so the post-release publishes.

## Post-merge expectation
Merging to `dev` changes both `pyproject.toml` versions → both publish workflows
trigger → `check` sees a forward move (post1 > base) → `publish` waits at
`pypi-production` approval → on approval, `nemtus-symbol-sdk 3.3.2.post1` and
`nemtus-catparser 3.2.0.post1` publish with the NEMTUS maintainer, and the `tag`
job creates `nemtus-symbol-sdk@3.3.2.post1` / `nemtus-catparser@3.2.0.post1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for the Python SDK and parser package.
  * Bumped package versions to post-release builds.
  * Changed maintainer contact information to the new support address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->