### PR TITLE
ci: mirror-sync hardening — keepalive, failure notify, upstream tag archive, release watch

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -37,7 +37,7 @@ py_parser_dir="${repo_root}/catbuffer/parser"
 readme="${repo_root}/README.md"
 
 # nemtus-owned GitHub workflows that must survive the strip below.
-nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml' 'pypi-sdk-publish.yml' 'pypi-catparser-publish.yml')
+nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml' 'pypi-sdk-publish.yml' 'pypi-catparser-publish.yml' 'upstream-release-watch.yml')
 
 echo "==> patching ${pkg_dir}/package.json"
 cd "${pkg_dir}"

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -17,19 +17,25 @@ name: mirror-sync (upstream symbol/symbol)
 #
 # Requires repo setting: Settings -> Actions -> General ->
 #   "Allow GitHub Actions to create and approve pull requests" = enabled.
+#
+# Companion jobs:
+#   - `keepalive` resets GitHub's 60-day scheduled-workflow auto-disable clock on
+#     every run. To stop a schedule permanently, DELETE its cron trigger — a manual
+#     "disable workflow" would just be re-enabled by the next keepalive.
+#   - `notify` pings Discord (org secret DISCORD_WEBHOOK_URL) when a scheduled run
+#     fails; it skips silently when the secret is not configured.
 
 on:
   schedule:
     - cron: '17 3 * * *'   # daily 03:17 UTC
   workflow_dispatch:
 
-permissions:
-  contents: write        # push the sync branch
-  pull-requests: write   # open the PR
-
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the sync branch
+      pull-requests: write   # open the PR
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -96,3 +102,39 @@ jobs:
               --title "Sync upstream symbol/symbol@${{ steps.check.outputs.upstream_sha }}" \
               --body "Automated mirror sync. Merges upstream symbol/symbol@dev and re-applies the @nemtus/symbol-sdk rename layer. After merge, publish.yml publishes if the version changed."
           fi
+
+  # Reset GitHub's 60-day scheduled-workflow auto-disable clock on every run
+  # (scheduled workflows in repos with no recent activity get disabled; upstream
+  # can be quiet for long stretches). Independent of the sync outcome.
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-enable scheduled workflows (60-day inactivity guard)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for wf in mirror-sync.yml; do
+            gh api -X PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}/enable"
+          done
+
+  # Push-notification on failure — a red scheduled run used to be the only signal.
+  # No third-party action: plain curl to a Discord webhook. Details stay in the
+  # run's step summary/logs; this is just the pager.
+  notify:
+    needs: [sync]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Notify Discord (mirror-sync failed)
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "${WEBHOOK}" ]; then
+            echo "DISCORD_WEBHOOK_URL not configured; skipping notification."
+            exit 0
+          fi
+          payload="$(jq -n --arg c "[mirror-sync] ${GITHUB_REPOSITORY} failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" '{content: $c}')"
+          curl -fsS -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -52,7 +52,9 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git remote add upstream https://github.com/symbol/symbol.git
-          git fetch upstream dev
+          # --no-tags: keep implicit tag auto-following out of refs/tags; upstream
+          # tags are archived explicitly by the upstream-tags job below.
+          git fetch --no-tags upstream dev
 
       - name: Build sync branch and decide (content-based)
         id: check
@@ -115,9 +117,49 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for wf in mirror-sync.yml; do
+          for wf in mirror-sync.yml upstream-release-watch.yml; do
             gh api -X PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}/enable"
           done
+
+  # Archive upstream release points on the fork WITHOUT touching refs/tags/*
+  # (RELEASE.md forbids pushing inherited upstream tags as tags): every upstream
+  # tag is mirrored append-only into the refs/upstream/tags/* namespace. Nothing
+  # in refs/tags/* changes, so image/publish tag triggers can never fire from
+  # upstream tag names. A rejected (non-fast-forward) push means upstream MOVED
+  # a tag — treated as a tamper alarm: the job fails and notify pages.
+  upstream-tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          persist-credentials: true
+
+      - name: Mirror upstream tags into refs/upstream/tags/* (append-only)
+        run: |
+          set -euo pipefail
+          git remote add upstream https://github.com/symbol/symbol.git
+          git fetch --no-tags upstream '+refs/tags/*:refs/upstream/tags/*'
+          # No --force, no --prune:
+          #   new tag       -> pushed
+          #   unchanged tag -> up-to-date no-op
+          #   moved tag     -> push rejected => fail loudly (possible history rewrite)
+          #   deleted tag   -> retained on the fork (DR posture)
+          if ! git push origin 'refs/upstream/tags/*:refs/upstream/tags/*' 2>push.log; then
+            {
+              echo '## upstream-tags: push rejected (moved upstream tag?)'
+              echo '```'
+              grep -E 'rejected|error' push.log || cat push.log
+              echo '```'
+              echo 'Investigate upstream intent before resolving — this alarm fires on upstream tag moves/rewrites.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            cat push.log
+            exit 1
+          fi
+          cat push.log
+          echo "archived upstream tags: $(git for-each-ref 'refs/upstream/tags' | wc -l)" >> "$GITHUB_STEP_SUMMARY"
 
   # Push-notification on failure — a red scheduled run used to be the only signal.
   # No third-party action: plain curl to a Discord webhook. Details stay in the

--- a/.github/workflows/upstream-release-watch.yml
+++ b/.github/workflows/upstream-release-watch.yml
@@ -1,0 +1,137 @@
+name: upstream-release-watch
+
+# Weekly watch that NEMTUS republished node images keep up with upstream client
+# releases, and that the cross-repo image-pin contract stays consistent:
+#   1. upstream symbol/symbol tags:   client/catapult/v* , rest/v*
+#   2. this repo's image-build tags:  catapult-image-v*  , rest-image-v*
+#      (pushing those tags builds+publishes ghcr.io/nemtus/{catapult-server,symbol-rest})
+#   3. nemtus/symbol-networks versions.env pins (branch main = mainnet)
+#
+# Pure report, no writes: findings go to the step summary and (when the
+# DISCORD_WEBHOOK_URL secret is configured) to Discord, prefixed [release-watch].
+# The bump itself stays human-ordered per the versions.env contract ("only bump
+# after the image is actually published"). The only failure case is a
+# MISCONFIGURATION: versions.env pinning an image version that is not published.
+#
+# NOTE: this filename must stay listed in BOTH
+#   - nemtus_workflows in .github/scripts/apply-nemtus-patch.sh (else mirror-sync strips it)
+#   - the keepalive list in mirror-sync.yml (else the 60-day auto-disable can stop it)
+
+on:
+  schedule:
+    - cron: '57 4 * * 2'   # weekly, Tuesday 04:57 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Compare upstream releases vs published images vs versions.env
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+
+          # Newest stable version for an upstream tag prefix, via anonymous
+          # ls-remote (no clone). Strict X.Y[.Z...] filter excludes rc/beta tags.
+          latest_upstream() {
+            git ls-remote --tags https://github.com/symbol/symbol.git "refs/tags/${1}*" \
+              | awk '{print $2}' | sed -e 's|^refs/tags/||' -e 's|\^{}$||' | sort -u \
+              | sed -n "s|^${1}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1
+          }
+          latest_local() {
+            git tag --list "${1}*" | sed -n "s|^${1}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1
+          }
+          newer() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
+
+          # Fail closed: an empty upstream tag list is a network/query anomaly,
+          # not "no releases" (these tags exist today).
+          up_cat="$(latest_upstream client/catapult/v)"
+          up_rest="$(latest_upstream rest/v)"
+          [ -n "${up_cat}" ]  || { echo "::error::empty upstream client/catapult tag list (network anomaly?)"; exit 1; }
+          [ -n "${up_rest}" ] || { echo "::error::empty upstream rest tag list (network anomaly?)"; exit 1; }
+
+          img_cat="$(latest_local catapult-image-v)"
+          img_rest="$(latest_local rest-image-v)"
+
+          env_file="$(curl -fsS https://raw.githubusercontent.com/nemtus/symbol-networks/main/.github/network-config/versions.env)"
+          pin_cat="$(printf '%s\n' "${env_file}" | sed -n 's/^CATAPULT_IMAGE_VERSION=v//p')"
+          pin_rest="$(printf '%s\n' "${env_file}" | sed -n 's/^REST_IMAGE_VERSION=v//p')"
+
+          findings=()
+          check_pair() { # label, upstream ver, image ver, pin ver, image tag prefix, env key, ghcr image
+            local label="$1" up="$2" img="$3" pin="$4" tagp="$5" key="$6" ghcr="$7"
+            if [ -z "${img}" ]; then
+              findings+=("ACTION(${label}): no ${tagp}* tag exists yet — create ${tagp}${up} to build/publish ${ghcr}")
+              return
+            fi
+            if newer "${up}" "${img}"; then
+              findings+=("ACTION(${label}): upstream v${up} > published image v${img} — create tag ${tagp}${up} (builds ${ghcr})")
+            fi
+            if [ -z "${pin}" ]; then
+              findings+=("WARN(${label}): ${key} not found in versions.env")
+              return
+            fi
+            if newer "${img}" "${pin}"; then
+              findings+=("ACTION(${label}): versions.env pins v${pin} but image v${img} is published — bump ${key} in nemtus/symbol-networks")
+            fi
+            if newer "${pin}" "${img}"; then
+              echo "::error::versions.env pins ${label} v${pin}, newer than the newest published image v${img} — an unpublished pin breaks 'docker compose pull' downstream."
+              exit 1
+            fi
+          }
+          check_pair catapult "${up_cat}"  "${img_cat}"  "${pin_cat}"  catapult-image-v CATAPULT_IMAGE_VERSION ghcr.io/nemtus/catapult-server
+          check_pair rest     "${up_rest}" "${img_rest}" "${pin_rest}" rest-image-v     REST_IMAGE_VERSION     ghcr.io/nemtus/symbol-rest
+
+          {
+            echo "## upstream-release-watch"
+            echo
+            echo "| component | upstream release | published image | versions.env pin |"
+            echo "| --- | --- | --- | --- |"
+            echo "| catapult | v${up_cat} | v${img_cat:--} | v${pin_cat:--} |"
+            echo "| rest | v${up_rest} | v${img_rest:--} | v${pin_rest:--} |"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${#findings[@]}" -eq 0 ]; then
+            echo "All aligned — nothing to do." >> "$GITHUB_STEP_SUMMARY"
+            echo "all aligned"
+            exit 0
+          fi
+
+          printf -- '- %s\n' "${findings[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ -n "${WEBHOOK}" ]; then
+            msg="$(printf '[release-watch] %s\n' "${GITHUB_REPOSITORY}"; printf -- '- %s\n' "${findings[@]}")"
+            payload="$(jq -n --arg c "${msg}" '{content: $c}')"
+            curl -fsS -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"
+          else
+            echo "DISCORD_WEBHOOK_URL not configured; step summary only."
+          fi
+
+  # Pager for real failures of the watch itself (network anomaly, misconfigured
+  # pin). Findings above are reported by the watch job directly.
+  notify:
+    needs: [watch]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Notify Discord (release-watch failed)
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "${WEBHOOK}" ]; then
+            echo "DISCORD_WEBHOOK_URL not configured; skipping notification."
+            exit 0
+          fi
+          payload="$(jq -n --arg c "[release-watch] ${GITHUB_REPOSITORY} run failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" '{content: $c}')"
+          curl -fsS -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -93,8 +93,28 @@ cannot collide with upstream's `sdk/python/v*` / `catbuffer/parser/v*` tags.)
   `git tag '@nemtus/symbol-sdk@3.3.2'`).
 - Bare `v3.0.x` tags and any `sdk/*` / `openapi/*` tags are legacy / upstream
   tags. Do not add new ones, and do not push the inherited upstream tags to
-  `origin`.
+  `origin` as tags. (Upstream tags ARE preserved on the fork automatically —
+  outside the tag namespace; see "Upstream tag archive" below.)
 - Do not tag the non-published `client/rest`.
+
+## Upstream tag archive
+
+`mirror-sync.yml`'s `upstream-tags` job mirrors every upstream `symbol/symbol` tag
+into this fork's `refs/upstream/tags/*` namespace (append-only: no force, no
+prune). Archived refs deliberately do NOT appear in `git tag` or the Releases UI —
+the visible tag namespace stays 100% NEMTUS release coordinates — but every
+upstream release point and its objects are preserved on the fork for disaster
+recovery / hard-fork readiness.
+
+- List them: `git ls-remote origin 'refs/upstream/tags/*'`
+- Local clones with the standard fetch-only `upstream` remote already carry the
+  same tags as `refs/remotes/upstream/tags/*`, fetched directly from upstream.
+- A rejected (non-fast-forward) push in that job means upstream **moved** a tag.
+  The failing run is the tamper alarm working as designed — investigate upstream
+  intent before resolving.
+- Hard-fork promotion: create a NEMTUS-named tag/branch pointing at the archived
+  ref (e.g. `git tag catapult-fork-base <sha>`); never republish bare upstream
+  tag names.
 
 ## Procedure
 


### PR DESCRIPTION
## Why

1. GitHub silently disables scheduled workflows after 60 days without repo activity — mirror repos legitimately go quiet when upstream does.
2. A failed scheduled run (merge conflict, network) is only a red run in the Actions tab — easy to miss.
3. Upstream tags exist nowhere under NEMTUS control (the fork carries only NEMTUS tags): if upstream vanished or rewrote history, its release points would be lost.
4. "New upstream client/REST release → build image tag → bump versions.env" is a manual cross-repo chain with no reminder.

## What

- **`keepalive` job** — re-enables this repo's scheduled workflows every run (`actions: write` only). Rule: to stop a schedule permanently, delete its cron trigger.
- **`notify` job** — on failure, POST the run URL to Discord via the `DISCORD_WEBHOOK_URL` org secret (plain curl, no marketplace action; skips when unset).
- **`upstream-tags` job** — archives every upstream tag into `refs/upstream/tags/*`, **append-only** (no force, no prune). `refs/tags/*` is never touched, so the RELEASE.md rule and the `catapult-image-v*` / `rest-image-v*` triggers cannot fire from upstream names. A rejected (non-fast-forward) push = upstream moved a tag = the job fails as a **tamper alarm**. The sync fetch gains `--no-tags`.
- **`upstream-release-watch.yml`** (weekly Tue) — three-way compare: upstream `client/catapult/v*` + `rest/v*` tags vs this repo's image tags vs `symbol-networks` `versions.env` pins; posts "ACTION: create tag catapult-image-vX / bump versions.env" to summary + Discord. Only an unpublished pin (pin > published image) fails the run. Added to the rename-layer allowlist (`apply-nemtus-patch.sh`) in the same PR, as mirror-ci requires.
- **Least privilege** — workflow-level permissions moved onto jobs (`sync`: contents+PR write; `keepalive`: actions write; `upstream-tags`: contents write; `notify`: none).
- **RELEASE.md** — new "Upstream tag archive" section (list/fetch/promotion procedure, alarm semantics); the "do not push inherited upstream tags" bullet now references the archive.

## Verification

- YAML validated; rename-layer parity gate passes locally with the new allowlist entry (`verify-rename-layer` equivalent: PASS).
- Release-watch comparison logic dry-run against real data: catapult upstream v1.0.3.9 = image v1.0.3.9 = pin v1.0.3.9; rest v2.5.1 = v2.5.1 = v2.5.1 → first run will report "all aligned". (The dry-run caught that upstream REST tags are `rest/v*`, not `client/rest/v*` — fixed.)
- No new `uses:` beyond the already-pinned `actions/checkout` — pinact unaffected.
- After merge: dispatch `mirror-sync.yml` once — expect `keepalive` 204s, `upstream-tags` to upload ~103 upstream tags (first run is the heavy one), and `git ls-remote origin 'refs/upstream/tags/*'` to list them. Then dispatch `upstream-release-watch.yml` — expect "all aligned".

Merge normally (any method — not an upstream-sync PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)