### PR TITLE
ci(publish): auto-create tag + Release after npm publishes

### DIFF
--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -42,7 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          # Pin the run to one commit: the pushed dev commit (or the dispatched
+          # ref tip). Keeps check/publish/tag all on the same tree even if dev
+          # advances mid-run, and matches the PyPI workflows.
+          ref: ${{ github.sha }}
           # This workflow never pushes to git (publishing is via OIDC), so don't
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
@@ -88,7 +91,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          # Same commit the check job evaluated (and the tag job will target).
+          ref: ${{ github.sha }}
           # This workflow never pushes to git (publishing is via OIDC), so don't
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
@@ -128,3 +132,35 @@ jobs:
 
       - name: Publish to npm (OIDC, provenance)
         run: npm publish --access public
+
+  # Record-keeping tag + GitHub Release for the version just published.
+  #
+  # SECURITY: contents: write is isolated to THIS job, which runs NO build and NO
+  # third-party code — only the `gh` CLI against the GitHub API. The build/publish
+  # job above stays at contents: read + id-token: write, so a supply-chain
+  # compromise in the npm build can never reach this write token. There is no
+  # checkout step (gh needs none), so nothing from the repo tree executes here.
+  tag:
+    needs: [check, publish]   # runs only if publish succeeded
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          tag="@nemtus/symbol-openapi@${VERSION}"
+          # Idempotent: a re-run (or a manual dispatch after a tag already exists)
+          # must not fail.
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "release ${tag} already exists; nothing to do."
+            exit 0
+          fi
+          # Tag the exact commit this run published from.
+          gh release create "${tag}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "@nemtus/symbol-openapi v${VERSION}" \
+            --notes "Mirror of upstream symbol/symbol. Published \`@nemtus/symbol-openapi\` ${VERSION} to npm."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          # Pin the run to one commit: the pushed dev commit (or the dispatched
+          # ref tip). Keeps check/publish/tag all on the same tree even if dev
+          # advances mid-run, and matches the PyPI workflows.
+          ref: ${{ github.sha }}
           # This workflow never pushes to git (publishing is via OIDC), so don't
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
@@ -86,7 +89,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: dev
+          # Same commit the check job evaluated (and the tag job will target).
+          ref: ${{ github.sha }}
           # This workflow never pushes to git (publishing is via OIDC), so don't
           # persist GITHUB_TOKEN into the local git config (zizmor: artipacked).
           persist-credentials: false
@@ -124,3 +128,35 @@ jobs:
 
       - name: Publish to npm (OIDC, provenance)
         run: npm publish --access public
+
+  # Record-keeping tag + GitHub Release for the version just published.
+  #
+  # SECURITY: contents: write is isolated to THIS job, which runs NO build and NO
+  # third-party code — only the `gh` CLI against the GitHub API. The build/publish
+  # job above stays at contents: read + id-token: write, so a supply-chain
+  # compromise in the npm build can never reach this write token. There is no
+  # checkout step (gh needs none), so nothing from the repo tree executes here.
+  tag:
+    needs: [check, publish]   # runs only if publish succeeded
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          tag="@nemtus/symbol-sdk@${VERSION}"
+          # Idempotent: a re-run (or a manual dispatch after a tag already exists)
+          # must not fail.
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "release ${tag} already exists; nothing to do."
+            exit 0
+          fi
+          # Tag the exact commit this run published from.
+          gh release create "${tag}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "@nemtus/symbol-sdk v${VERSION}" \
+            --notes "Mirror of upstream symbol/symbol. Published \`@nemtus/symbol-sdk\` ${VERSION} to npm."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,9 @@
 # RELEASE — Release / Tag Conventions
 
 This repository is a rename-republish mirror of upstream `symbol/symbol`, and the
-monorepo hosts multiple artifacts side by side. This document defines the
-conventions for **manually creating tags and GitHub Releases**.
+monorepo hosts multiple artifacts side by side. This document defines the tag /
+GitHub Release conventions. Tags and Releases are created **automatically by the
+publish workflows**; the manual procedure below remains as a recovery fallback.
 
 ## Published artifacts
 
@@ -47,13 +48,14 @@ conventions for **manually creating tags and GitHub Releases**.
   > environment `pypi-production`) before the first run, and create the
   > `pypi-production` GitHub environment with required reviewers.
 
-  **Tagging differs by ecosystem.** The npm workflows do NOT tag (see the manual
-  procedure below). The **PyPI workflows tag automatically**: after a successful
-  publish, a separate `tag` job creates `nemtus-symbol-sdk@<version>` /
-  `nemtus-catparser@<version>` and a matching GitHub Release. That job is the only
-  place `contents: write` is granted, and it runs **no build and no third-party
-  code** (just the `gh` CLI), so the `contents: read` build/publish job is never
-  exposed to a write token. The job is idempotent (skips if the release exists).
+  **All four publish paths tag automatically.** After a successful publish, a
+  separate `tag` job creates the package-coordinate tag
+  (`@nemtus/symbol-sdk@<version>`, `@nemtus/symbol-openapi@<version>`,
+  `nemtus-symbol-sdk@<version>`, `nemtus-catparser@<version>`) and a matching
+  GitHub Release. That job is the only place `contents: write` is granted, and it
+  runs **no build and no third-party code** (just the `gh` CLI), so the
+  `contents: read` build/publish job is never exposed to a write token. The job
+  is idempotent (skips if the release exists).
 - Therefore **tags / Releases are not the publish trigger; they are record-keeping
   markers** that pin "which commit corresponds to which version of which artifact."
 
@@ -96,9 +98,12 @@ cannot collide with upstream's `sdk/python/v*` / `catbuffer/parser/v*` tags.)
   `origin`.
 - Do not tag the non-published `client/rest`.
 
-## Procedure
+## Manual procedure (fallback)
 
-Create the tag / Release **after npm publishing has completed.**
+Normally unnecessary — the `tag` jobs create the tag + Release automatically after
+every successful publish. Use this only for recovery (e.g. a deleted tag, or a
+publish that predates the automation). Create the tag / Release **after npm
+publishing has completed.**
 
 1. A mirror-sync PR is merged into `dev`.
 2. `publish.yml` / `openapi-publish.yml` completes the npm publish
@@ -147,10 +152,9 @@ gh release create '@nemtus/symbol-openapi@1.0.6' --repo nemtus/symbol \
       remote, so `gh` resolves the default repo to `symbol/symbol` and would
       otherwise target the wrong repository.
 
-## Future automation (reference)
+## Automation status
 
-Today the flow is "publish via version-diff → tag manually." To avoid missing
-tags, a step that automatically creates the tag + Release could be added after
-the successful publish step in each workflow (this would require granting
-`permissions: contents: write` and revisiting the auth setup used for the push).
-For now, the manual procedure in this document is the rule.
+Implemented: all four publish workflows (npm and PyPI) auto-create the tag +
+Release via an isolated `tag` job — `contents: write` is granted only there, and
+the job runs no build, no third-party code, and no checkout. The manual procedure
+above remains as a recovery fallback.


### PR DESCRIPTION
## Why

RELEASE.md's "Future automation" item: the npm publish flow (`publish.yml`, `openapi-publish.yml`) still required manually creating the `@nemtus/<pkg>@<version>` tag + Release after each publish — easy to forget, and the PyPI workflows already solved this safely.

## What

- New `tag` job in both npm publish workflows, cloned from the PyPI precedent (`pypi-sdk-publish.yml`): `needs: [check, publish]`, `permissions: contents: write` **isolated to this job only** (no build, no third-party code, no checkout — just `gh release create`), idempotent via `gh release view`.
- Checkout alignment: both workflows now pin `ref: ${{ github.sha }}` (was the moving `dev` ref), so check/publish/tag all operate on the exact commit that is also the Release `--target` — matching the PyPI workflows.
- RELEASE.md updated: all four publish paths auto-tag; manual procedure demoted to a recovery fallback; "Future automation" closed as implemented.

## Verification

- YAML validated locally; no new `uses:` (pinact unaffected); rename-layer parity unaffected (these files are not rewritten by the patch script).
- Verified organically on the next real publish: expect the `tag` job to create `@nemtus/symbol-sdk@<ver>` / `@nemtus/symbol-openapi@<ver>` right after the `npm-production`-approved publish succeeds.

Note: this PR and #42 both touch RELEASE.md in different sections; merge order does not matter, but if git reports a trivial context conflict, take both hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publish workflows now automatically create GitHub Releases and tags after successful releases.
  * Release automation is now applied across all supported package ecosystems.

* **Bug Fixes**
  * Workflow runs now use the exact commit being published, reducing the risk of mismatched release artifacts.
  * Release creation is idempotent, so reruns skip duplicates if a release already exists.

* **Documentation**
  * Updated release guidance to reflect the new automation-first process and clarify manual steps are now fallback-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->