### PR TITLE
fix(mirror-sync): verify-only upstream-tags job + page on its failure

### DIFF
--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -193,4 +193,5 @@ jobs:
             exit 0
           fi
           payload="$(jq -n --arg c "[mirror-sync] ${GITHUB_REPOSITORY} failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" '{content: $c}')"
-          curl -fsS -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"
+          # --retry handles transient Discord 429/5xx (honors Retry-After).
+          curl -fsS --retry 3 -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -121,51 +121,65 @@ jobs:
             gh api -X PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}/enable"
           done
 
-  # Archive upstream release points on the fork WITHOUT touching refs/tags/*
-  # (RELEASE.md forbids pushing inherited upstream tags as tags): every upstream
-  # tag is mirrored append-only into the refs/upstream/tags/* namespace. Nothing
-  # in refs/tags/* changes, so image/publish tag triggers can never fire from
-  # upstream tag names. A rejected (non-fast-forward) push means upstream MOVED
-  # a tag — treated as a tamper alarm: the job fails and notify pages.
+  # Verify the upstream tag archive (refs/upstream/tags/* on this fork) against
+  # upstream — VERIFY-ONLY, no push. GITHUB_TOKEN cannot create refs whose trees
+  # contain workflow files (GitHub demands a `workflows` permission that is not
+  # grantable to GITHUB_TOKEN), and most upstream tags contain upstream's own
+  # .github/workflows/* — so the archive itself is pushed from the maintainer
+  # lane instead (`nemtus-ops sync-local`; see RELEASE.md "Upstream tag archive").
+  # This job keeps the tamper alarm: a MOVED tag (archived value != upstream
+  # value) fails the run, and notify pages Discord. Pure ls-remote comparison:
+  # no checkout, no object download, no credentials.
   upstream-tags:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: dev
-          persist-credentials: true
-
-      - name: Mirror upstream tags into refs/upstream/tags/* (append-only)
+      - name: Verify archived upstream tags (tamper alarm)
         run: |
           set -euo pipefail
-          git remote add upstream https://github.com/symbol/symbol.git
-          git fetch --no-tags upstream '+refs/tags/*:refs/upstream/tags/*'
-          # No --force, no --prune:
-          #   new tag       -> pushed
-          #   unchanged tag -> up-to-date no-op
-          #   moved tag     -> push rejected => fail loudly (possible history rewrite)
-          #   deleted tag   -> retained on the fork (DR posture)
-          if ! git push origin 'refs/upstream/tags/*:refs/upstream/tags/*' 2>push.log; then
-            {
-              echo '## upstream-tags: push rejected (moved upstream tag?)'
-              echo '```'
-              grep -E 'rejected|error' push.log || cat push.log
-              echo '```'
-              echo 'Investigate upstream intent before resolving — this alarm fires on upstream tag moves/rewrites.'
-            } >> "$GITHUB_STEP_SUMMARY"
-            cat push.log
+          # "name<TAB>sha" per tag, peeled ^{} rows excluded (both sides store
+          # the same tag *object* ids, so comparing un-peeled ids is exact).
+          git ls-remote https://github.com/symbol/symbol.git 'refs/tags/*' \
+            | grep -v '\^{}$' | awk -F'\t' '{sub("^refs/tags/","",$2); print $2 "\t" $1}' | sort > upstream.txt
+          git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" 'refs/upstream/tags/*' \
+            | grep -v '\^{}$' | awk -F'\t' '{sub("^refs/upstream/tags/","",$2); print $2 "\t" $1}' | sort > archive.txt
+          # Fail closed on an empty upstream listing (network anomaly, not "no tags").
+          [ -s upstream.txt ] || { echo "::error::empty upstream tag list (network anomaly?)"; exit 1; }
+
+          moved="$(join -t "$(printf '\t')" upstream.txt archive.txt | awk -F'\t' '$2 != $3')"
+          missing="$(join -t "$(printf '\t')" -v1 upstream.txt archive.txt | cut -f1)"
+          retained="$(join -t "$(printf '\t')" -v2 upstream.txt archive.txt | cut -f1)"
+
+          {
+            echo "## upstream tag archive check"
+            echo "- upstream tags: $(wc -l < upstream.txt) / archived on fork: $(wc -l < archive.txt)"
+            if [ -n "${missing}" ]; then
+              echo "- NOT YET ARCHIVED ($(printf '%s\n' "${missing}" | wc -l)) — run \`nemtus-ops sync-local\` on the maintainer machine:"
+              printf '%s\n' "${missing}" | sed 's/^/    - /'
+            fi
+            if [ -n "${retained}" ]; then
+              echo "- retained after upstream deletion (DR posture): $(printf '%s\n' "${retained}" | wc -l)"
+            fi
+            if [ -n "${moved}" ]; then
+              echo "- MOVED (TAMPER ALARM):"
+              printf '%s\n' "${moved}" | sed 's/^/    - /'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "${moved}" ]; then
+            echo "::error::upstream tag(s) moved vs the archived values — possible history rewrite. Investigate upstream intent before re-archiving (see RELEASE.md)."
+            printf '%s\n' "${moved}"
             exit 1
           fi
-          cat push.log
-          echo "archived upstream tags: $(git for-each-ref 'refs/upstream/tags' | wc -l)" >> "$GITHUB_STEP_SUMMARY"
+          [ -n "${missing}" ] && echo "note: new upstream tag(s) await archiving from the maintainer lane." || echo "archive complete and value-exact."
 
   # Push-notification on failure — a red scheduled run used to be the only signal.
-  # No third-party action: plain curl to a Discord webhook. Details stay in the
-  # run's step summary/logs; this is just the pager.
+  # Covers BOTH the sync job and the upstream-tags tamper alarm. No third-party
+  # action: plain curl to a Discord webhook. Details stay in the run's step
+  # summary/logs; this is just the pager.
   notify:
-    needs: [sync]
+    needs: [sync, upstream-tags]
     if: failure()
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -140,10 +140,14 @@ jobs:
           set -euo pipefail
           # "name<TAB>sha" per tag, peeled ^{} rows excluded (both sides store
           # the same tag *object* ids, so comparing un-peeled ids is exact).
+          # The peeled-row filter lives INSIDE awk: a separate `grep -v` exits 1
+          # on empty ls-remote output and, under pipefail, would abort the step
+          # before the explicit empty-input handling below (empty upstream ->
+          # ::error; empty archive -> "not yet archived" reporting).
           git ls-remote https://github.com/symbol/symbol.git 'refs/tags/*' \
-            | grep -v '\^{}$' | awk -F'\t' '{sub("^refs/tags/","",$2); print $2 "\t" $1}' | sort > upstream.txt
+            | awk -F'\t' '$2 !~ /\^[{][}]$/ {sub("^refs/tags/","",$2); print $2 "\t" $1}' | sort > upstream.txt
           git ls-remote "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" 'refs/upstream/tags/*' \
-            | grep -v '\^{}$' | awk -F'\t' '{sub("^refs/upstream/tags/","",$2); print $2 "\t" $1}' | sort > archive.txt
+            | awk -F'\t' '$2 !~ /\^[{][}]$/ {sub("^refs/upstream/tags/","",$2); print $2 "\t" $1}' | sort > archive.txt
           # Fail closed on an empty upstream listing (network anomaly, not "no tags").
           [ -s upstream.txt ] || { echo "::error::empty upstream tag list (network anomaly?)"; exit 1; }
 

--- a/.github/workflows/upstream-release-watch.yml
+++ b/.github/workflows/upstream-release-watch.yml
@@ -29,49 +29,38 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: dev
-          fetch-tags: true
-          persist-credentials: false
-
+      # No checkout: everything is read via anonymous ls-remote / curl.
+      # (checkout with fetch-tags:true + the default shallow depth did not
+      # actually deliver this repo's tags on the first run — ls-remote is
+      # exact, cheaper, and token-free.)
       - name: Compare upstream releases vs published images vs versions.env
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           set -euo pipefail
 
-          # Robustness notes (learned from the first run, which died in ~200ms
-          # with zero output):
-          # - Every helper ends in `|| true`: under `set -euo pipefail` a
-          #   pipeline whose grep matches nothing exits 1 and kills the whole
-          #   script through the command substitution, silently. Empty results
-          #   are legitimate and handled explicitly below.
-          # - The upstream ls-remote clears the checkout's inherited auth
-          #   header: sending this repo's token to another repository can make
-          #   the request fail instead of falling back to anonymous.
-          latest_upstream() {
-            { git -c http.https://github.com/.extraheader= \
-                ls-remote --tags https://github.com/symbol/symbol.git "refs/tags/${1}*" \
-                | awk '{print $2}' | sed -e 's|^refs/tags/||' -e 's|\^{}$||' | sort -u \
-                | sed -n "s|^${1}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1; } || true
-          }
-          latest_local() {
-            { git tag --list "${1}*" | sed -n "s|^${1}||p" \
-                | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1; } || true
+          # Robustness (learned from the first runs): every helper ends in
+          # `|| true` — under `set -euo pipefail` a pipeline whose grep matches
+          # nothing exits 1 and would kill the whole script through the command
+          # substitution, silently. Empty results are legitimate and handled
+          # explicitly below.
+          latest_tag() { # $1 = repo url, $2 = tag prefix; newest stable X.Y[.Z..]
+            { git ls-remote "${1}" "refs/tags/${2}*" \
+                | grep -v '\^{}$' | awk '{print $2}' | sed -e 's|^refs/tags/||' | sort -u \
+                | sed -n "s|^${2}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1; } || true
           }
           newer() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
 
           echo "collecting versions..."
           # Fail closed: an empty upstream tag list is a network/query anomaly,
           # not "no releases" (these tags exist today).
-          up_cat="$(latest_upstream client/catapult/v)"
-          up_rest="$(latest_upstream rest/v)"
+          up_cat="$(latest_tag https://github.com/symbol/symbol.git client/catapult/v)"
+          up_rest="$(latest_tag https://github.com/symbol/symbol.git rest/v)"
           [ -n "${up_cat}" ]  || { echo "::error::empty upstream client/catapult tag list (network anomaly?)"; exit 1; }
           [ -n "${up_rest}" ] || { echo "::error::empty upstream rest tag list (network anomaly?)"; exit 1; }
 
-          img_cat="$(latest_local catapult-image-v)"
-          img_rest="$(latest_local rest-image-v)"
+          img_cat="$(latest_tag "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" catapult-image-v)"
+          img_rest="$(latest_tag "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" rest-image-v)"
 
           env_file="$(curl -fsS https://raw.githubusercontent.com/nemtus/symbol-networks/main/.github/network-config/versions.env)"
           pin_cat="$(printf '%s\n' "${env_file}" | sed -n 's/^CATAPULT_IMAGE_VERSION=v//p')"
@@ -125,7 +114,10 @@ jobs:
           if [ -n "${WEBHOOK}" ]; then
             msg="$(printf '[release-watch] %s\n' "${GITHUB_REPOSITORY}"; printf -- '- %s\n' "${findings[@]}")"
             payload="$(jq -n --arg c "${msg}" '{content: $c}')"
-            curl -fsS -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"
+            # --retry handles transient Discord 429/5xx (honors Retry-After).
+            # If delivery still fails the job goes red on purpose: findings are
+            # in the summary, and the failure email flags the broken channel.
+            curl -fsS --retry 3 -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"
           else
             echo "DISCORD_WEBHOOK_URL not configured; step summary only."
           fi
@@ -147,4 +139,4 @@ jobs:
             exit 0
           fi
           payload="$(jq -n --arg c "[release-watch] ${GITHUB_REPOSITORY} run failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" '{content: $c}')"
-          curl -fsS -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"
+          curl -fsS --retry 3 -H 'Content-Type: application/json' -d "${payload}" "${WEBHOOK}"

--- a/.github/workflows/upstream-release-watch.yml
+++ b/.github/workflows/upstream-release-watch.yml
@@ -41,18 +41,28 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Newest stable version for an upstream tag prefix, via anonymous
-          # ls-remote (no clone). Strict X.Y[.Z...] filter excludes rc/beta tags.
+          # Robustness notes (learned from the first run, which died in ~200ms
+          # with zero output):
+          # - Every helper ends in `|| true`: under `set -euo pipefail` a
+          #   pipeline whose grep matches nothing exits 1 and kills the whole
+          #   script through the command substitution, silently. Empty results
+          #   are legitimate and handled explicitly below.
+          # - The upstream ls-remote clears the checkout's inherited auth
+          #   header: sending this repo's token to another repository can make
+          #   the request fail instead of falling back to anonymous.
           latest_upstream() {
-            git ls-remote --tags https://github.com/symbol/symbol.git "refs/tags/${1}*" \
-              | awk '{print $2}' | sed -e 's|^refs/tags/||' -e 's|\^{}$||' | sort -u \
-              | sed -n "s|^${1}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1
+            { git -c http.https://github.com/.extraheader= \
+                ls-remote --tags https://github.com/symbol/symbol.git "refs/tags/${1}*" \
+                | awk '{print $2}' | sed -e 's|^refs/tags/||' -e 's|\^{}$||' | sort -u \
+                | sed -n "s|^${1}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1; } || true
           }
           latest_local() {
-            git tag --list "${1}*" | sed -n "s|^${1}||p" | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1
+            { git tag --list "${1}*" | sed -n "s|^${1}||p" \
+                | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -1; } || true
           }
           newer() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
 
+          echo "collecting versions..."
           # Fail closed: an empty upstream tag list is a network/query anomaly,
           # not "no releases" (these tags exist today).
           up_cat="$(latest_upstream client/catapult/v)"
@@ -66,6 +76,9 @@ jobs:
           env_file="$(curl -fsS https://raw.githubusercontent.com/nemtus/symbol-networks/main/.github/network-config/versions.env)"
           pin_cat="$(printf '%s\n' "${env_file}" | sed -n 's/^CATAPULT_IMAGE_VERSION=v//p')"
           pin_rest="$(printf '%s\n' "${env_file}" | sed -n 's/^REST_IMAGE_VERSION=v//p')"
+          echo "upstream: catapult=v${up_cat} rest=v${up_rest}"
+          echo "images:   catapult=v${img_cat:-none} rest=v${img_rest:-none}"
+          echo "pins:     catapult=v${pin_cat:-none} rest=v${pin_rest:-none}"
 
           findings=()
           check_pair() { # label, upstream ver, image ver, pin ver, image tag prefix, env key, ghcr image

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -101,19 +101,31 @@ cannot collide with upstream's `sdk/python/v*` / `catbuffer/parser/v*` tags.)
 
 ## Upstream tag archive
 
-`mirror-sync.yml`'s `upstream-tags` job mirrors every upstream `symbol/symbol` tag
-into this fork's `refs/upstream/tags/*` namespace (append-only: no force, no
-prune). Archived refs deliberately do NOT appear in `git tag` or the Releases UI —
-the visible tag namespace stays 100% NEMTUS release coordinates — but every
-upstream release point and its objects are preserved on the fork for disaster
-recovery / hard-fork readiness.
+Every upstream `symbol/symbol` tag is mirrored into this fork's
+`refs/upstream/tags/*` namespace (append-only). Archived refs deliberately do NOT
+appear in `git tag` or the Releases UI — the visible tag namespace stays 100%
+NEMTUS release coordinates — but every upstream release point and its objects are
+preserved on the fork for disaster recovery / hard-fork readiness.
 
-- List them: `git ls-remote origin 'refs/upstream/tags/*'`
+Division of labor (GitHub constraint: GITHUB_TOKEN cannot create refs whose trees
+contain workflow files — a `workflows` permission it can never be granted — and
+most upstream tags contain upstream's `.github/workflows/*`):
+
+- **Archiving (push)** happens from the **maintainer lane**, whose fine-grained
+  PAT carries Workflows RW: `nemtus-ops sync-local` pushes
+  `refs/remotes/upstream/tags/* -> refs/upstream/tags/*` (no force — a rejected
+  push means the archived value differs; investigate before overriding).
+- **Verification (tamper alarm)** is `mirror-sync.yml`'s `upstream-tags` job:
+  a credential-free ls-remote comparison of upstream vs the archive on every
+  scheduled run. A **moved** tag (archived value != upstream value) fails the run
+  and pages Discord — investigate upstream intent before re-archiving. New
+  not-yet-archived tags are reported in the run summary (not a failure).
+
+Reference:
+
+- List the archive: `git ls-remote origin 'refs/upstream/tags/*'`
 - Local clones with the standard fetch-only `upstream` remote already carry the
   same tags as `refs/remotes/upstream/tags/*`, fetched directly from upstream.
-- A rejected (non-fast-forward) push in that job means upstream **moved** a tag.
-  The failing run is the tamper alarm working as designed — investigate upstream
-  intent before resolving.
 - Hard-fork promotion: create a NEMTUS-named tag/branch pointing at the archived
   ref (e.g. `git tag catapult-fork-base <sha>`); never republish bare upstream
   tag names.


### PR DESCRIPTION
## What broke

First scheduled run after #42: the `upstream-tags` push was rejected per-ref with
`refusing to allow a GitHub App to create or update workflow '.github/workflows/...' without 'workflows' permission` ([failed run](https://github.com/nemtus/symbol/actions/runs/28776568157/job/85321854482)). This is a GitHub platform rule: **GITHUB_TOKEN cannot create refs whose trees contain workflow files**, and the required `workflows` permission is not grantable to GITHUB_TOKEN at all. Most upstream tags contain upstream's own `.github/workflows/*`, so a CI-side archive push can never work. (82 of 103 refs made it through; the rest were rejected.)

A second gap surfaced by the same run: `notify` had `needs: [sync]`, so the upstream-tags failure produced a red run **without paging Discord**.

## Fix

- **`upstream-tags` job → verify-only** (credential-free): two `git ls-remote` listings (upstream `refs/tags/*` vs this fork's `refs/upstream/tags/*`, peeled rows excluded) compared with `join`. Fails **only** when an archived value differs from upstream — the tamper alarm, preserved. New not-yet-archived tags are listed in the summary as a maintainer to-do, not a failure. `permissions: contents: read`, no checkout, no object download.
- **Archive push moved to the maintainer lane** (fine-grained PAT with Workflows RW): `nemtus-ops sync-local` pushes `refs/remotes/upstream/tags/* -> refs/upstream/tags/*` (companion PR in nemtus/.github). **Already executed: the archive is complete — 103/103 refs on the fork, value-exact vs upstream.**
- **`notify` now `needs: [sync, upstream-tags]`** so the alarm actually pages.
- RELEASE.md: documents the constraint and the push/verify division of labor.

## Verification

- YAML validated; the exact ls-remote/join logic dry-run against live endpoints: `upstream: 103 / archived: 103, moved: none, missing: none, retained: none`.
- No `uses:` in the reworked job at all (pinact unaffected); rename-layer parity untouched.
- After merge, the next scheduled run (or one `workflow_dispatch`) should show `upstream-tags: archive complete and value-exact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag integrity checks so mirrored tags are now verified against upstream and any moved or altered tags are flagged.
  * Added safer handling for cases where no upstream tags are found, preventing silent failures.

* **Documentation**
  * Clarified how upstream tags are archived and verified.
  * Expanded guidance on what users can expect when viewing archived tags and how to inspect them locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->