### PR TITLE
ci(crypto-wasm): publish @nemtus/symbol-crypto-wasm-{web,node,bundler} mirror

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -37,7 +37,7 @@ py_parser_dir="${repo_root}/catbuffer/parser"
 readme="${repo_root}/README.md"
 
 # nemtus-owned GitHub workflows that must survive the strip below.
-nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml' 'pypi-sdk-publish.yml' 'pypi-catparser-publish.yml' 'upstream-release-watch.yml')
+nemtus_workflows=('publish.yml' 'openapi-publish.yml' 'crypto-wasm-publish.yml' 'mirror-sync.yml' 'pinact.yml' 'mirror-ci.yml' 'catapult-image.yml' 'rest-image.yml' 'pypi-sdk-publish.yml' 'pypi-catparser-publish.yml' 'upstream-release-watch.yml')
 
 echo "==> patching ${pkg_dir}/package.json"
 cd "${pkg_dir}"

--- a/.github/scripts/build-crypto-wasm.sh
+++ b/.github/scripts/build-crypto-wasm.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# build-crypto-wasm.sh <variant: web|node|bundler> <version> <out_dir>
+#
+# nemtus republish layer for the Symbol crypto WASM packages. Upstream builds a
+# single Rust crate (sdk/javascript/wasm, crate name `symbol-crypto-wasm`) into
+# three separately-named npm packages via wasm-pack targets:
+#
+#   variant   wasm-pack --target   npm package                        consumers
+#   -------   ------------------   --------------------------------   -------------------------
+#   web       web                  @nemtus/symbol-crypto-wasm-web     browser / webpack SPA
+#   bundler   bundler              @nemtus/symbol-crypto-wasm-bundler Vite / Rollup / modern SPA
+#   node      nodejs               @nemtus/symbol-crypto-wasm-node    Node / SSR (also the SDK dep)
+#
+# This script builds ONE variant and turns wasm-pack's generated package (named
+# after the crate, `symbol-crypto-wasm`, versioned from Cargo.toml `0.1.0`) into
+# the scoped nemtus mirror package: only the npm name, version and repository
+# metadata change; the compiled wasm + JS glue are unmodified. The <version> is
+# passed in (the publish workflow mirrors upstream's npm version) — it is NOT read
+# from Cargo.toml, because the published wasm packages are versioned independently
+# of the crate.
+#
+# No `--out-name` is passed, so wasm-pack keeps the crate-derived file stem
+# `symbol_crypto_wasm` (=> `symbol_crypto_wasm.js` + `symbol_crypto_wasm_bg.wasm`),
+# matching upstream's packages and the import path documented in
+# sdk/javascript/README.md (`.../symbol-crypto-wasm-web/symbol_crypto_wasm.js`).
+#
+# Idempotent: re-running against a fresh <out_dir> produces the same result.
+set -euo pipefail
+
+variant="${1:?usage: build-crypto-wasm.sh <web|node|bundler> <version> <out_dir>}"
+version="${2:?usage: build-crypto-wasm.sh <web|node|bundler> <version> <out_dir>}"
+out_dir="${3:?usage: build-crypto-wasm.sh <web|node|bundler> <version> <out_dir>}"
+
+case "${variant}" in
+	web)     wasm_target='web' ;;
+	bundler) wasm_target='bundler' ;;
+	node)    wasm_target='nodejs' ;;
+	*) echo "::error::unknown variant '${variant}' (expected web|node|bundler)" >&2; exit 1 ;;
+esac
+
+pkg_name="@nemtus/symbol-crypto-wasm-${variant}"
+repo_root="$(git rev-parse --show-toplevel)"
+crate_dir="${repo_root}/sdk/javascript/wasm"
+
+# Resolve out_dir to an absolute path before we cd into the crate (wasm-pack's
+# --out-dir is relative to the crate dir otherwise).
+mkdir -p "${out_dir}"
+out_dir="$(cd "${out_dir}" && pwd)"
+
+echo "==> building ${pkg_name}@${version} (wasm-pack --target ${wasm_target}) -> ${out_dir}"
+(
+	cd "${crate_dir}"
+	# --release: optimized build; --no-typescript: matches upstream/build.sh (the
+	# published packages ship no .d.ts). No --out-name: keep the `symbol_crypto_wasm`
+	# stem so the output is drop-in compatible with upstream.
+	wasm-pack build --release --no-typescript --target "${wasm_target}" --out-dir "${out_dir}"
+)
+
+# wasm-pack drops a .gitignore in the out dir; harmless, but remove it so it can't
+# be mistaken for repo content (this dir is a throwaway build artifact).
+rm -f "${out_dir}/.gitignore"
+
+echo "==> stamping nemtus mirror metadata onto ${out_dir}/package.json"
+(
+	cd "${out_dir}"
+	# wasm-pack writes name="symbol-crypto-wasm", version=<Cargo.toml>. Override the
+	# published identity; leave the wasm-pack `files`/`main`/`module`/`collaborators`
+	# fields intact (they describe the actual artifact and its authorship).
+	npm pkg set name="${pkg_name}"
+	npm pkg set version="${version}"
+	npm pkg set description="Symbol crypto WASM (${variant} build) — nemtus mirror of symbol-crypto-wasm-${variant}; only the npm package name differs from upstream."
+	npm pkg set license='MIT'
+	npm pkg set publishConfig.access='public'
+	npm pkg set repository.type='git'
+	npm pkg set repository.url='git+https://github.com/nemtus/symbol.git'
+	npm pkg set bugs='https://github.com/nemtus/symbol/issues'
+	npm pkg set homepage='https://github.com/nemtus/symbol/tree/dev/sdk/javascript/wasm#readme'
+)
+
+# MIT LICENSE — mirror sdk/javascript's stance exactly: the crate declares NO
+# `license` field and NO copyright holder (Cargo.toml `authors` is contact
+# metadata, not a copyright statement), so we do NOT fabricate a `Copyright (c)`
+# line. We pass through the MIT permission text with a truthful provenance note and
+# an explicit disclaimer that the mirror holds no copyright. npm auto-includes a
+# LICENSE regardless of the package's "files".
+echo "==> writing ${out_dir}/LICENSE"
+cat > "${out_dir}/LICENSE" <<EOF
+MIT License
+
+This package is an unmodified redistribution of the Symbol crypto WASM \`${wasm_target}\`
+build (upstream npm package \`symbol-crypto-wasm-${variant}\`) compiled from the
+\`symbol-crypto-wasm\` Rust crate in the upstream project symbol/symbol
+(https://github.com/symbol/symbol), authored by its contributors — identified in
+the upstream crate metadata as "Symbol Contributors <contributors@symbol.dev>".
+The nemtus mirror asserts no copyright over this software and changes nothing but
+the npm package name. The authoritative copyright and license are upstream's.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+EOF
+
+# The root repo README notice does not travel inside the npm tarball, so ship a
+# per-package mirror notice. wasm-pack may have generated a default README; we
+# overwrite it with the nemtus notice.
+echo "==> writing ${out_dir}/README.md"
+cat > "${out_dir}/README.md" <<EOF
+<!-- nemtus-mirror-notice -->
+# ${pkg_name}
+
+> **Note (nemtus mirror):** This package is a content mirror of the Symbol crypto
+> WASM \`${wasm_target}\` build from
+> [\`symbol/symbol\`](https://github.com/symbol/symbol) (\`sdk/javascript/wasm\`,
+> upstream npm name \`symbol-crypto-wasm-${variant}\`). The only change from upstream
+> is the npm package name; the compiled WebAssembly and JavaScript glue are
+> unmodified. It provides the Ed25519 crypto used by
+> [\`@nemtus/symbol-sdk\`](https://www.npmjs.com/package/@nemtus/symbol-sdk).
+> For the canonical project, see
+> [symbol/symbol](https://github.com/symbol/symbol).
+<!-- /nemtus-mirror-notice -->
+
+This build is produced with \`wasm-pack build --target ${wasm_target}\` and exposes
+\`symbol_crypto_wasm.js\` + \`symbol_crypto_wasm_bg.wasm\` at the package root, matching
+upstream's layout.
+EOF
+
+echo "==> done: ${pkg_name}@${version} staged in ${out_dir}"

--- a/.github/workflows/crypto-wasm-publish.yml
+++ b/.github/workflows/crypto-wasm-publish.yml
@@ -1,0 +1,189 @@
+name: publish @nemtus/symbol-crypto-wasm-*
+
+# Trusted publish path for the three scoped Symbol crypto-WASM mirror packages:
+#   @nemtus/symbol-crypto-wasm-web      (browser / webpack SPA)
+#   @nemtus/symbol-crypto-wasm-bundler  (Vite / Rollup / modern SPA bundlers)
+#   @nemtus/symbol-crypto-wasm-node     (Node / SSR; also @nemtus/symbol-sdk's dep)
+#
+# All three are compiled from the single upstream Rust crate at sdk/javascript/wasm
+# via wasm-pack (targets web / bundler / nodejs) — see .github/scripts/build-crypto-wasm.sh.
+# Only the npm package name changes vs upstream; the compiled artifact is unmodified.
+#
+# Versioning: the crypto-wasm packages are versioned INDEPENDENTLY of the Rust crate
+# (Cargo.toml 0.1.0) and the JS SDK, and that version lives nowhere in the tree. So we
+# mirror upstream's npm version directly: read `npm view symbol-crypto-wasm-web version`
+# and publish each @nemtus variant that is not already at that version. This makes the
+# mirror self-updating with no in-tree version file to maintain. Because there is no
+# in-tree trigger file, this runs on a daily schedule (cheap: the check is just `npm
+# view`; the expensive wasm build only runs when a publish is actually due) plus manual
+# dispatch (with an optional version override for the initial bootstrap / re-publish).
+#
+# Publishing uses npm Trusted Publishing (OIDC) — NO long-lived NPM_TOKEN. The
+# `npm-production` environment carries a required-reviewers rule, so publishing pauses
+# for manual approval.
+#
+# npmjs.com Trusted Publisher config must match, for EACH of the three packages:
+#   repository:  nemtus/symbol
+#   workflow:    crypto-wasm-publish.yml
+#   environment: npm-production
+
+on:
+  schedule:
+    # Daily, after mirror-sync (17 3) so we build a freshly-synced crate.
+    - cron: '47 3 * * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Override version to publish (default: mirror upstream symbol-crypto-wasm-web).'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crypto-wasm-publish
+  cancel-in-progress: false
+
+jobs:
+  # Decide the target version (upstream npm, or the dispatch override) and which of the
+  # three @nemtus variants are behind it. Kept separate so the npm-production approval
+  # prompt only appears when we actually intend to publish, and so the expensive wasm
+  # build is skipped entirely on the (usual) no-op day.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.decide.outputs.should_publish }}
+      version: ${{ steps.decide.outputs.version }}
+      variants: ${{ steps.decide.outputs.variants }}
+    steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      - name: Decide target version and lagging variants
+        id: decide
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          # Target version: the dispatch override, else upstream's npm version.
+          # The three upstream variants are published in lockstep, so symbol-crypto-wasm-web
+          # is the canonical source. Fail closed if upstream can't be read (it exists, so an
+          # empty read is a transient registry/network error, not a real 0.0.0).
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+            echo "using dispatch override version ${version}"
+          elif upstream="$(npm view symbol-crypto-wasm-web version 2>/dev/null)" && [ -n "${upstream}" ]; then
+            version="${upstream}"
+            echo "mirroring upstream symbol-crypto-wasm-web version ${version}"
+          else
+            echo "::error::could not read symbol-crypto-wasm-web version from npm; aborting to avoid a bad publish." >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          # A @nemtus variant needs publishing when it is not already at `version`. An
+          # empty read here is legitimate (the package may not exist yet on first run) and
+          # means "publish", so we do NOT fail closed on the @nemtus side.
+          variants=''
+          for v in web bundler node; do
+            ours="$(npm view "@nemtus/symbol-crypto-wasm-${v}" version 2>/dev/null || true)"
+            if [ "${ours}" != "${version}" ]; then
+              echo "@nemtus/symbol-crypto-wasm-${v}: ${ours:-<none>} -> ${version}: will publish."
+              variants="${variants} ${v}"
+            else
+              echo "@nemtus/symbol-crypto-wasm-${v}: already at ${version}: skip."
+            fi
+          done
+          variants="$(echo ${variants} | xargs || true)"   # trim
+          echo "variants=${variants}" >> "$GITHUB_OUTPUT"
+          if [ -n "${variants}" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Build + publish each lagging variant. A single job (not a matrix) so the whole
+  # release passes ONE npm-production approval and installs the Rust toolchain once.
+  publish:
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-production
+    permissions:
+      id-token: write   # required for npm Trusted Publishing (OIDC)
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Pin the run to one commit so check/publish/tag share a tree even if dev
+          # advances mid-run. This workflow never pushes to git (publish is via OIDC),
+          # so don't persist GITHUB_TOKEN into git config (zizmor: artipacked).
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing requires npm CLI >= 11.5.1.
+      - name: Upgrade npm to OIDC-capable version
+        run: npm install -g npm@11.5.1
+
+      # rustup is preinstalled on ubuntu-latest. Pin rustc 1.86.0 to match
+      # sdk/javascript/scripts/ci/build.sh (stays there until the wasm-opt issue is fixed).
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.86.0 --profile minimal
+          rustup default 1.86.0
+          rustup target add wasm32-unknown-unknown
+          rustc --version
+
+      # Install wasm-pack from source (no third-party action, no curl-pipe installer).
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked --version 0.13.1
+
+      - name: Build and publish lagging variants
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
+          VARIANTS: ${{ needs.check.outputs.variants }}
+        run: |
+          for v in ${VARIANTS}; do
+            out="./_build/wasm/${v}_pkg"
+            bash .github/scripts/build-crypto-wasm.sh "${v}" "${VERSION}" "${out}"
+            ( cd "${out}" && npm publish --access public )
+          done
+
+  # Record-keeping tags + GitHub Releases for the versions just published.
+  #
+  # SECURITY: contents: write is isolated to THIS job, which runs NO build and NO
+  # third-party code — only the `gh` CLI against the GitHub API. The build/publish job
+  # stays at contents: read + id-token: write, so a supply-chain compromise in the build
+  # can never reach this write token. No checkout step, so nothing from the repo executes.
+  tag:
+    needs: [check, publish]   # runs only if publish succeeded
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create tags and GitHub Releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
+          VARIANTS: ${{ needs.check.outputs.variants }}
+        run: |
+          for v in ${VARIANTS}; do
+            pkg="@nemtus/symbol-crypto-wasm-${v}"
+            tag="${pkg}@${VERSION}"
+            # Idempotent: a re-run (or a dispatch after a tag exists) must not fail.
+            if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "release ${tag} already exists; skipping."
+              continue
+            fi
+            gh release create "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${GITHUB_SHA}" \
+              --title "${pkg} v${VERSION}" \
+              --notes "Mirror of upstream symbol/symbol. Published \`${pkg}\` ${VERSION} to npm."
+          done

--- a/.github/workflows/mirror-ci.yml
+++ b/.github/workflows/mirror-ci.yml
@@ -122,6 +122,34 @@ jobs:
       - run: npm run bundle                              # dist/* (webpack + wasm-pack)
       - run: npx tsc -p ./tsconfig/build-bindings.json   # ts/src/* declarations
 
+  # Build-parity for the crypto-wasm publish path (crypto-wasm-publish.yml): a synced
+  # crate that fails to wasm-pack-build for any of the three targets must fail HERE, at
+  # PR time, before the publish workflow tries to build and publish it. Build-only — no
+  # publish, so the version is a throwaway placeholder. rustup is preinstalled on the
+  # runner; pin rustc 1.86.0 to match sdk/javascript/scripts/ci/build.sh.
+  crypto-wasm-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.86.0 --profile minimal
+          rustup default 1.86.0
+          rustup target add wasm32-unknown-unknown
+          rustc --version
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked --version 0.13.1
+      - name: Build all three variants (web / bundler / node)
+        run: |
+          for v in web bundler node; do
+            bash .github/scripts/build-crypto-wasm.sh "$v" 0.0.0-ci "./_build/wasm/${v}_pkg"
+          done
+
   vectors:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## What & why

The Symbol crypto-WASM npm packages (browser/bundler/node Ed25519) were the **last runtime dependency of `@nemtus/symbol-sdk` still pulled from upstream npm**, and NEMTUS published no `@nemtus/*` browser-crypto package for JS/TS SPA use. This adds a mirror-publish path for all three variants.

No new fork was needed: `symbol-crypto-wasm-*` has no separate upstream repo — all three variants build from the single Rust crate already mirrored at `sdk/javascript/wasm` (`symbol-crypto-wasm`, crate v0.1.0).

## What this adds

Modeled on `openapi-publish.yml`:

- **`.github/scripts/build-crypto-wasm.sh`** — `wasm-pack build` per variant (web/bundler/nodejs), stamping the `@nemtus/*` name/version/metadata + LICENSE/README onto wasm-pack's output. No `--out-name`, so the `symbol_crypto_wasm.js` stem matches upstream and the import path documented in `sdk/javascript/README.md`.
- **`.github/workflows/crypto-wasm-publish.yml`** — OIDC Trusted Publishing behind the `npm-production` environment (no `NPM_TOKEN`). A single publish job loops the lagging variants → **one** approval, toolchain installed once. Versions mirror upstream npm (`npm view symbol-crypto-wasm-web version`); `schedule` + `workflow_dispatch`, because the wasm packages are versioned **independently** of the crate/SDK with no in-tree version file.
- **`.github/workflows/mirror-ci.yml`** — a `crypto-wasm-build` job builds all three targets so a sync that breaks the wasm build fails at PR time.
- **`apply-nemtus-patch.sh`** — `crypto-wasm-publish.yml` added to the `nemtus_workflows` allow-list so mirror-sync doesn't strip it.

## Verification (local)

- ✅ All three variants build under pinned `rustc 1.86.0` / `wasm-pack 0.13.1`.
- ✅ `npm publish --dry-run` tarballs correct: web/node = 5 files, bundler = 6 (the wasm-pack `.gitignore` is removed; only intended files ship).
- ✅ **Functional crypto**: the built `node` artifact derives the canonical Symbol test-vector public key, signs+verifies a round trip, and rejects a tampered signature.
- ✅ `apply-nemtus-patch.sh` no-drift holds on the current `dev` tree, and `crypto-wasm-publish.yml` survives the workflow strip.
- ✅ Workflow YAML valid; every `uses:` SHA-pinned.

## After merge

npm Trusted Publisher for the three packages is already configured (repo `nemtus/symbol`, workflow `crypto-wasm-publish.yml`, env `npm-production`). Once merged, run **crypto-wasm-publish.yml** → the check job sees placeholder `0.0.1` ≠ upstream `0.1.1` → approve the `npm-production` gate → all three publish `0.1.1` with provenance and tag GitHub Releases.

## Follow-up (not in this PR)

Repointing `@nemtus/symbol-sdk`'s optional dependency to `@nemtus/symbol-crypto-wasm-node` (via npm alias, no source edits) is deliberately deferred: it can only land once these packages exist on npm, otherwise mirror-ci's `npm ci` breaks on an unresolvable lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)