### PR TITLE
ci(release): auto-generate release notes + registry qualifier in publish workflows

### DIFF
--- a/.github/workflows/crypto-wasm-publish.yml
+++ b/.github/workflows/crypto-wasm-publish.yml
@@ -181,9 +181,22 @@ jobs:
               echo "release ${tag} already exists; skipping."
               continue
             fi
+            # Previous release of THIS package (same coordinate), newest first, minus current.
+            prev="$(gh release list --repo "${GITHUB_REPOSITORY}" -L 200 --json tagName -q '.[].tagName' \
+              | grep -F "${pkg}@" | grep -vxF "${tag}" | head -n1 || true)"
+            # GitHub auto-generated notes (merged PRs + contributors + changelog) — same as the
+            # web "Generate release notes" button — prepended with the mirror provenance line.
+            provenance="Mirror of upstream symbol/symbol. Published \`${pkg}\` ${VERSION} to npm."
+            if notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+                -f tag_name="${tag}" -f target_commitish="${GITHUB_SHA}" \
+                ${prev:+-f previous_tag_name="${prev}"} -q '.body' 2>/dev/null)" && [ -n "${notes}" ]; then
+              body="$(printf '%s\n\n%s\n' "${provenance}" "${notes}")"
+            else
+              body="${provenance}"
+            fi
             gh release create "${tag}" \
               --repo "${GITHUB_REPOSITORY}" \
               --target "${GITHUB_SHA}" \
-              --title "${pkg} v${VERSION}" \
-              --notes "Mirror of upstream symbol/symbol. Published \`${pkg}\` ${VERSION} to npm."
+              --title "${pkg} v${VERSION} · npm" \
+              --notes "${body}"
           done

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -151,16 +151,30 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.check.outputs.version }}
         run: |
-          tag="@nemtus/symbol-openapi@${VERSION}"
+          pkg="@nemtus/symbol-openapi"
+          tag="${pkg}@${VERSION}"
           # Idempotent: a re-run (or a manual dispatch after a tag already exists)
           # must not fail.
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "release ${tag} already exists; nothing to do."
             exit 0
           fi
+          # Previous release of THIS package (same coordinate), newest first, minus current.
+          prev="$(gh release list --repo "${GITHUB_REPOSITORY}" -L 200 --json tagName -q '.[].tagName' \
+            | grep -F "${pkg}@" | grep -vxF "${tag}" | head -n1 || true)"
+          # GitHub auto-generated notes (merged PRs + contributors + changelog) — same as the
+          # web "Generate release notes" button — prepended with the mirror provenance line.
+          provenance="Mirror of upstream symbol/symbol. Published \`${pkg}\` ${VERSION} to npm."
+          if notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${tag}" -f target_commitish="${GITHUB_SHA}" \
+              ${prev:+-f previous_tag_name="${prev}"} -q '.body' 2>/dev/null)" && [ -n "${notes}" ]; then
+            body="$(printf '%s\n\n%s\n' "${provenance}" "${notes}")"
+          else
+            body="${provenance}"
+          fi
           # Tag the exact commit this run published from.
           gh release create "${tag}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \
-            --title "@nemtus/symbol-openapi v${VERSION}" \
-            --notes "Mirror of upstream symbol/symbol. Published \`@nemtus/symbol-openapi\` ${VERSION} to npm."
+            --title "${pkg} v${VERSION} · npm" \
+            --notes "${body}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,16 +147,30 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.check.outputs.version }}
         run: |
-          tag="@nemtus/symbol-sdk@${VERSION}"
+          pkg="@nemtus/symbol-sdk"
+          tag="${pkg}@${VERSION}"
           # Idempotent: a re-run (or a manual dispatch after a tag already exists)
           # must not fail.
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "release ${tag} already exists; nothing to do."
             exit 0
           fi
+          # Previous release of THIS package (same coordinate), newest first, minus current.
+          prev="$(gh release list --repo "${GITHUB_REPOSITORY}" -L 200 --json tagName -q '.[].tagName' \
+            | grep -F "${pkg}@" | grep -vxF "${tag}" | head -n1 || true)"
+          # GitHub auto-generated notes (merged PRs + contributors + changelog) — same as the
+          # web "Generate release notes" button — prepended with the mirror provenance line.
+          provenance="Mirror of upstream symbol/symbol. Published \`${pkg}\` ${VERSION} to npm."
+          if notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${tag}" -f target_commitish="${GITHUB_SHA}" \
+              ${prev:+-f previous_tag_name="${prev}"} -q '.body' 2>/dev/null)" && [ -n "${notes}" ]; then
+            body="$(printf '%s\n\n%s\n' "${provenance}" "${notes}")"
+          else
+            body="${provenance}"
+          fi
           # Tag the exact commit this run published from.
           gh release create "${tag}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \
-            --title "@nemtus/symbol-sdk v${VERSION}" \
-            --notes "Mirror of upstream symbol/symbol. Published \`@nemtus/symbol-sdk\` ${VERSION} to npm."
+            --title "${pkg} v${VERSION} · npm" \
+            --notes "${body}"

--- a/.github/workflows/pypi-catparser-publish.yml
+++ b/.github/workflows/pypi-catparser-publish.yml
@@ -166,10 +166,23 @@ jobs:
             echo "release ${tag} already exists; nothing to do."
             exit 0
           fi
+          # Previous release of THIS package (same coordinate), newest first, minus current.
+          prev="$(gh release list --repo "${GITHUB_REPOSITORY}" -L 200 --json tagName -q '.[].tagName' \
+            | grep -F "${PYPI_NAME}@" | grep -vxF "${tag}" | head -n1 || true)"
+          # GitHub auto-generated notes (merged PRs + contributors + changelog) — same as the
+          # web "Generate release notes" button — prepended with the mirror provenance line.
+          provenance="Mirror of upstream symbol/symbol. Published \`${PYPI_NAME}\` ${VERSION} to PyPI (import module: catparser)."
+          if notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${tag}" -f target_commitish="${GITHUB_SHA}" \
+              ${prev:+-f previous_tag_name="${prev}"} -q '.body' 2>/dev/null)" && [ -n "${notes}" ]; then
+            body="$(printf '%s\n\n%s\n' "${provenance}" "${notes}")"
+          else
+            body="${provenance}"
+          fi
           # Tag the exact commit this run published from (the dev commit carrying the
           # published pyproject for a push; the dispatched dev tip otherwise).
           gh release create "${tag}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \
-            --title "${PYPI_NAME} v${VERSION}" \
-            --notes "Mirror of upstream symbol/symbol. Published \`${PYPI_NAME}\` ${VERSION} to PyPI (import module: catparser)."
+            --title "${PYPI_NAME} v${VERSION} · PyPI" \
+            --notes "${body}"

--- a/.github/workflows/pypi-sdk-publish.yml
+++ b/.github/workflows/pypi-sdk-publish.yml
@@ -179,10 +179,23 @@ jobs:
             echo "release ${tag} already exists; nothing to do."
             exit 0
           fi
+          # Previous release of THIS package (same coordinate), newest first, minus current.
+          prev="$(gh release list --repo "${GITHUB_REPOSITORY}" -L 200 --json tagName -q '.[].tagName' \
+            | grep -F "${PYPI_NAME}@" | grep -vxF "${tag}" | head -n1 || true)"
+          # GitHub auto-generated notes (merged PRs + contributors + changelog) — same as the
+          # web "Generate release notes" button — prepended with the mirror provenance line.
+          provenance="Mirror of upstream symbol/symbol. Published \`${PYPI_NAME}\` ${VERSION} to PyPI (import module: symbolchain)."
+          if notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${tag}" -f target_commitish="${GITHUB_SHA}" \
+              ${prev:+-f previous_tag_name="${prev}"} -q '.body' 2>/dev/null)" && [ -n "${notes}" ]; then
+            body="$(printf '%s\n\n%s\n' "${provenance}" "${notes}")"
+          else
+            body="${provenance}"
+          fi
           # Tag the exact commit this run published from (the dev commit carrying the
           # published pyproject for a push; the dispatched dev tip otherwise).
           gh release create "${tag}" \
             --repo "${GITHUB_REPOSITORY}" \
             --target "${GITHUB_SHA}" \
-            --title "${PYPI_NAME} v${VERSION}" \
-            --notes "Mirror of upstream symbol/symbol. Published \`${PYPI_NAME}\` ${VERSION} to PyPI (import module: symbolchain)."
+            --title "${PYPI_NAME} v${VERSION} · PyPI" \
+            --notes "${body}"


### PR DESCRIPTION
## What & why

Two improvements to GitHub Release notes, applied consistently to **all five** publish workflows (`publish.yml`, `openapi-publish.yml`, `crypto-wasm-publish.yml`, `pypi-sdk-publish.yml`, `pypi-catparser-publish.yml`).

### 1. Registry qualifier in the title

Release titles now end with `· npm` or `· PyPI`:

- `@nemtus/symbol-sdk v3.3.2 · npm`
- `@nemtus/symbol-crypto-wasm-web v0.1.1 · npm`
- `nemtus-symbol-sdk v3.3.2 · PyPI`

The npm titles already all carried `@`; the only `@`/no-`@` variance in the releases list is npm (scoped `@nemtus/…`) vs PyPI (flat `nemtus-…`), which are the packages' **real names**. Forcing `@nemtus/` onto the PyPI titles was considered and rejected: it would misrepresent the PyPI name and produce a release title identical to the npm package's. The registry qualifier makes the list scannable without either problem.

### 2. Auto-generated notes (PRs + contributors)

Each tag job now composes the release body from GitHub's `releases/generate-notes` API — the same **"What's Changed" (merged PRs) + New Contributors + Full Changelog** content as the web "Generate release notes" button — keyed to the **previous release of the same package** (the package coordinate is grepped out of the release list; `previous_tag_name` is omitted on a first release). The existing one-line mirror provenance note is kept as a header; on API failure the body falls back to provenance-only.

## Security posture preserved

The tag jobs remain **checkout-free** — only `gh` CLI / REST calls, no repo code — so the isolated `contents: write` token never touches build code.

## Verification

- ✅ All five workflows parse as YAML; every `uses:` still SHA-pinned.
- ✅ `apply-nemtus-patch.sh` no-drift holds; all five workflows survive the mirror-sync allow-list strip.
- ✅ The exact tag-job snippet was run read-only against the live repo (`@nemtus/symbol-sdk` 3.3.2): it detected the previous tag `@nemtus/symbol-sdk@3.3.1` and produced provenance + What's Changed (8 PRs, contributors) + Full Changelog compare link.

## Effect

Existing releases are unchanged; the new format applies to the **next** publish of each package (the tag jobs are idempotent and skip already-tagged versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub releases now use autogenerated notes instead of a fixed message for multiple package publish workflows.
  * Release titles were updated to clearly label npm and PyPI publishes.
  * Previous release tags are now used to generate more relevant changelog ranges when available.

* **Bug Fixes**
  * If auto-generated notes are unavailable, releases now fall back to a basic provenance message so release creation still succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->