### PR TITLE
feat(sdk): repoint @nemtus/symbol-sdk crypto-wasm dep at the nemtus mirror

### DIFF
--- a/.github/scripts/apply-nemtus-patch.sh
+++ b/.github/scripts/apply-nemtus-patch.sh
@@ -50,6 +50,21 @@ npm pkg set repository.type='git'
 npm pkg set repository.url='git+https://github.com/nemtus/symbol.git'
 npm pkg set bugs='https://github.com/nemtus/symbol/issues'
 npm pkg set homepage='https://github.com/nemtus/symbol/tree/dev/sdk/javascript#readme'
+# Repoint the optional crypto-wasm dependency at the nemtus mirror via an npm alias.
+# The dependency KEY stays 'symbol-crypto-wasm-node' (so src/impl/ed25519_wasm.js's
+# import and webpack.config.js's NormalModuleReplacementPlugin regex need no change),
+# but it resolves to @nemtus/symbol-crypto-wasm-node instead of upstream's package —
+# closing the last runtime dependency on an upstream-published npm package. Only the
+# package NAME changes; upstream's version RANGE is preserved (read from whatever is
+# declared now), so the SDK keeps tracking upstream. Idempotent: extracting the range
+# from an already-aliased value yields the same alias. The SDK lockfile must match this
+# alias; mirror-sync.yml regenerates it (npm install --package-lock-only) right after
+# this script runs, and the committed lockfile on dev already reflects it.
+wasm_dep="$(npm pkg get 'optionalDependencies.symbol-crypto-wasm-node' | tr -d '"')"
+if [ -n "${wasm_dep}" ] && [ "${wasm_dep}" != '{}' ]; then
+	wasm_range="${wasm_dep##*@}"
+	npm pkg set "optionalDependencies.symbol-crypto-wasm-node=npm:@nemtus/symbol-crypto-wasm-node@${wasm_range}"
+fi
 # NOTE: "version" is intentionally NOT modified — it always tracks upstream.
 
 echo "==> patching ${openapi_dir}/package.json"

--- a/.github/scripts/relock-sdk.sh
+++ b/.github/scripts/relock-sdk.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# relock-sdk.sh
+#
+# Regenerate sdk/javascript/package-lock.json after apply-nemtus-patch.sh has repointed
+# the crypto-wasm optional dependency at the nemtus mirror
+# (symbol-crypto-wasm-node -> npm:@nemtus/symbol-crypto-wasm-node). The aliased
+# package.json and the lockfile must agree, or `npm ci` in mirror-ci.yml / publish.yml
+# fails (or silently installs upstream's package).
+#
+# npm's `--package-lock-only` reuses an existing lockfile node when its version still
+# satisfies the range, so it does NOT re-point an already-present same-version entry to
+# the alias target. We therefore drop that one entry first, which forces npm to
+# re-resolve it against @nemtus/symbol-crypto-wasm-node; every other entry is left
+# untouched, keeping the diff minimal.
+#
+# Run by mirror-sync.yml (which has network) right after apply-nemtus-patch.sh. It is
+# deliberately NOT part of apply-nemtus-patch.sh: that script must stay offline and
+# lockfile-free so mirror-ci.yml's verify-rename-layer no-drift check (which runs the
+# patch without a network regen) stays valid.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}/sdk/javascript"
+
+# Drop the crypto-wasm lockfile node so the alias is resolved fresh (see header).
+node -e 'const fs=require("fs"),f="package-lock.json";const j=JSON.parse(fs.readFileSync(f));if(j.packages)delete j.packages["node_modules/symbol-crypto-wasm-node"];fs.writeFileSync(f,JSON.stringify(j,null,2)+"\n");'
+
+# Rewrite the lockfile from package.json without touching node_modules or running
+# install scripts. npm normalizes formatting, so the committed lockfile stays canonical.
+npm install --package-lock-only --ignore-scripts

--- a/.github/workflows/mirror-sync.yml
+++ b/.github/workflows/mirror-sync.yml
@@ -72,6 +72,10 @@ jobs:
           # Prefer upstream on any conflict; the rename layer is restored next.
           git merge -X theirs --no-edit --no-commit upstream/dev || true
           bash .github/scripts/apply-nemtus-patch.sh
+          # The rename layer repoints @nemtus/symbol-sdk's optional crypto-wasm dep at the
+          # @nemtus mirror via an npm alias; regenerate the SDK lockfile so it stays in sync
+          # with the aliased package.json (mirror-ci/publish.yml `npm ci` need them consistent).
+          bash .github/scripts/relock-sdk.sh
           git add -A
 
           # Content guard: if the merged + re-renamed tree is identical to dev,

--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "symbol-sdk",
+  "name": "@nemtus/symbol-sdk",
   "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "symbol-sdk",
+      "name": "@nemtus/symbol-sdk",
       "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
@@ -45,7 +45,7 @@
         "yargs": "~18.0.0"
       },
       "optionalDependencies": {
-        "symbol-crypto-wasm-node": "^0.1.1"
+        "symbol-crypto-wasm-node": "npm:@nemtus/symbol-crypto-wasm-node@^0.1.1"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -6329,9 +6329,11 @@
       }
     },
     "node_modules/symbol-crypto-wasm-node": {
+      "name": "@nemtus/symbol-crypto-wasm-node",
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/symbol-crypto-wasm-node/-/symbol-crypto-wasm-node-0.1.1.tgz",
-      "integrity": "sha512-gASOhy8+uITSZh5bCYKve5GFtQQ2yQjTFqYNRO4Wq5mH29Ai+3TyKTAq9wZ6bwQfgm7j8U4aqmwFn9WdsXU4eQ==",
+      "resolved": "https://registry.npmjs.org/@nemtus/symbol-crypto-wasm-node/-/symbol-crypto-wasm-node-0.1.1.tgz",
+      "integrity": "sha512-SthviQ5TDB7owe07xg0nFxIV90qbbALfnuh8SutLTdyqf7tZqapqwfl/UkP3rALaPBxXh7iXZrNwvgpdN6pXFw==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/tapable": {

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -82,7 +82,7 @@
     "ts/src/*"
   ],
   "optionalDependencies": {
-    "symbol-crypto-wasm-node": "^0.1.1"
+    "symbol-crypto-wasm-node": "npm:@nemtus/symbol-crypto-wasm-node@^0.1.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What & why

Phase 2 of the crypto-wasm mirror (follow-up to the now-merged #47). `@nemtus/symbol-sdk`'s only remaining runtime dependency on an **upstream-published** npm package was its optional `symbol-crypto-wasm-node`. Now that `@nemtus/symbol-crypto-wasm-{web,node,bundler}` are live on npm, this repoints the SDK at the mirror so the whole runtime chain is self-owned.

## How — an npm alias (no source edits)

`apply-nemtus-patch.sh` now rewrites the optional dep to:

```json
"symbol-crypto-wasm-node": "npm:@nemtus/symbol-crypto-wasm-node@^0.1.1"
```

The dependency **key** stays `symbol-crypto-wasm-node`, so:
- `src/impl/ed25519_wasm.js`'s `import … from 'symbol-crypto-wasm-node'` is unchanged, and
- `webpack.config.js`'s `NormalModuleReplacementPlugin(/symbol-crypto-wasm-node/, …)` (browser build) still matches.

It's still a **name-only** mirror delta. The patch preserves upstream's version **range** (only the package name is aliased), so the SDK keeps tracking upstream, and the alias is idempotent (re-extracting the range from an already-aliased value yields the same value → mirror-ci no-drift stays green).

## Lockfile handling (the delicate bit)

The aliased `package.json` needs a matching `package-lock.json`. npm's `--package-lock-only` reuses an existing same-version node and does **not** re-point an aliased dep, so **`.github/scripts/relock-sdk.sh`** drops that one lockfile entry and regenerates. `mirror-sync.yml` runs it right after the rename layer on every sync, so sync PRs carry a correct lockfile. `relock` is deliberately **not** part of `apply-nemtus-patch.sh` — that script stays offline/lockfile-free so `mirror-ci`'s `verify-rename-layer` no-drift check (which runs the patch without a network regen) remains valid.

The committed lockfile diff is minimal: the aliased root entry + the `node_modules/symbol-crypto-wasm-node` node now carrying `name: @nemtus/symbol-crypto-wasm-node` and the `@nemtus/` resolved URL/integrity (plus a stale root `name` field corrected from `symbol-sdk` → `@nemtus/symbol-sdk`).

## Verification (local)

- ✅ `npm ci` against the aliased lockfile succeeds — package.json and lockfile are in sync.
- ✅ The `symbol-crypto-wasm-node` specifier now installs **`@nemtus/symbol-crypto-wasm-node@0.1.1`**.
- ✅ A Symbol test-vector keypair derivation matches through the aliased package.
- ✅ `apply-nemtus-patch.sh` is idempotent (package.json unchanged on re-run; lockfile untouched by the patch); `relock-sdk.sh` is idempotent.
- ✅ `mirror-sync.yml` parses as YAML.

## Effect

The repoint reaches published npm on the **next** `@nemtus/symbol-sdk` version bump (publish is version-diff gated). Until then the last-published SDK keeps using upstream's package, exactly as today — it self-heals on the next upstream SDK bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)